### PR TITLE
feat(db): Design schema and entities for orders and positions #7

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
         "@nestjs/jwt": "^11.0.0",
+        "@nestjs/mapped-types": "*",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/platform-socket.io": "^11.1.3",
@@ -2607,6 +2608,26 @@
       },
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/passport": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
     "@nestjs/jwt": "^11.0.0",
+    "@nestjs/mapped-types": "*",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/platform-socket.io": "^11.1.3",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -7,10 +7,20 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersModule } from './users/users.module';
 import { AuthModule } from './auth/auth.module';
-import { User } from './users/entities/user.entity'; // User 엔티티 직접 임포트
 import { BinanceModule } from './binance/binance.module';
 import { EventsGateway } from './events/events.gateway';
 import { EventsModule } from './events/events.module';
+import { OrdersModule } from './orders/orders.module';
+import { PositionsModule } from './positions/positions.module';
+import { WalletsModule } from './wallets/wallets.module';
+import { TransactionsModule } from './transactions/transactions.module';
+
+// 엔티티 임포트
+import { User } from './users/entities/user.entity';
+import { Order } from './orders/entities/order.entity';
+import { Position } from './positions/entities/position.entity';
+import { Wallet } from './wallets/entities/wallet.entity';
+import { Transaction } from './transactions/entities/transaction.entity';
 
 @Module({
   imports: [
@@ -37,7 +47,7 @@ import { EventsModule } from './events/events.module';
         // entities: [__dirname + '/../**/*.entity{.ts,.js}'], // 이 방식은 가끔 문제를 일으킴
 
         // entities를 직접 지정하는 방식으로 변경하여 안정성 확보
-        entities: [User], // User 엔티티를 직접 임포트해서 사용
+        entities: [User, Order, Position, Wallet, Transaction], // User 엔티티를 직접 임포트해서 사용
 
         // synchronize는 개발 환경에서만 true로 설정해야 합니다.
         // process.env.NODE_ENV가 'production'이 아닐 때만 true가 되도록 설정
@@ -52,6 +62,10 @@ import { EventsModule } from './events/events.module';
     AuthModule,
     BinanceModule,
     EventsModule,
+    OrdersModule,
+    PositionsModule,
+    WalletsModule,
+    TransactionsModule,
   ],
   controllers: [AppController],
   providers: [AppService, EventsGateway],

--- a/backend/src/common/enums/order.enum.ts
+++ b/backend/src/common/enums/order.enum.ts
@@ -1,0 +1,22 @@
+// backend/src/common/enums/order.enum.ts
+
+export enum OrderType {
+  LIMIT = 'LIMIT',
+  MARKET = 'MARKET',
+}
+
+export enum OrderSide {
+  BUY = 'BUY', // Long 포지션 진입 또는 Short 포지션 종료
+  SELL = 'SELL', // Short 포지션 진입 또는 Long 포지션 종료
+}
+
+export enum PositionSide {
+  LONG = 'LONG',
+  SHORT = 'SHORT',
+}
+
+export enum OrderStatus {
+  NEW = 'NEW', // 체결 대기 (지정가)
+  FILLED = 'FILLED', // 완전 체결
+  CANCELED = 'CANCELED', // 취소
+}

--- a/backend/src/orders/dto/create-order.dto.ts
+++ b/backend/src/orders/dto/create-order.dto.ts
@@ -1,0 +1,1 @@
+export class CreateOrderDto {}

--- a/backend/src/orders/dto/update-order.dto.ts
+++ b/backend/src/orders/dto/update-order.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateOrderDto } from './create-order.dto';
+
+export class UpdateOrderDto extends PartialType(CreateOrderDto) {}

--- a/backend/src/orders/entities/order.entity.ts
+++ b/backend/src/orders/entities/order.entity.ts
@@ -1,0 +1,53 @@
+// backend/src/orders/entities/order.entity.ts
+
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import {
+  OrderSide,
+  OrderStatus,
+  OrderType,
+} from '../../common/enums/order.enum';
+
+@Entity({ name: 'orders' })
+export class Order {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  // User(1) : Order(N) 관계 설정
+  // "한 명의 사용자(User)는 여러 개의 주문(Order)을 할 수 있다"는 관계
+  // eager : 기본적으로 주문 정보를 조회할 때마다 연결된 사용자 정보 전체를 항상 같이 불러오지는 않겠다는 설정
+  @ManyToOne(() => User, (user) => user.id, { eager: false })
+  user: User;
+
+  @Column()
+  symbol: string; // 예: BTCUSDT
+
+  @Column({ type: 'enum', enum: OrderType })
+  type: OrderType;
+
+  @Column({ type: 'enum', enum: OrderSide })
+  side: OrderSide;
+
+  // decimal 타입은 소수점을 매우 정확하게 저장 금융계산에서 오류 방지
+  @Column({ type: 'decimal', precision: 20, scale: 10, default: 0.0 })
+  price: number; // 주문 가격 (시장가 주문 시 0)
+
+  @Column({ type: 'decimal', precision: 20, scale: 10 })
+  quantity: number; // 주문 수량
+
+  @Column({ type: 'enum', enum: OrderStatus, default: OrderStatus.NEW })
+  status: OrderStatus; // NEW, FILLED, CANCELED
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/orders/orders.controller.ts
+++ b/backend/src/orders/orders.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { OrdersService } from './orders.service';
+import { CreateOrderDto } from './dto/create-order.dto';
+import { UpdateOrderDto } from './dto/update-order.dto';
+
+@Controller('orders')
+export class OrdersController {
+  constructor(private readonly ordersService: OrdersService) {}
+
+  @Post()
+  create(@Body() createOrderDto: CreateOrderDto) {
+    return this.ordersService.create(createOrderDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.ordersService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.ordersService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateOrderDto: UpdateOrderDto) {
+    return this.ordersService.update(+id, updateOrderDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.ordersService.remove(+id);
+  }
+}

--- a/backend/src/orders/orders.module.ts
+++ b/backend/src/orders/orders.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { OrdersService } from './orders.service';
+import { OrdersController } from './orders.controller';
+
+@Module({
+  controllers: [OrdersController],
+  providers: [OrdersService],
+})
+export class OrdersModule {}

--- a/backend/src/orders/orders.service.ts
+++ b/backend/src/orders/orders.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateOrderDto } from './dto/create-order.dto';
+import { UpdateOrderDto } from './dto/update-order.dto';
+
+@Injectable()
+export class OrdersService {
+  create(createOrderDto: CreateOrderDto) {
+    return 'This action adds a new order';
+  }
+
+  findAll() {
+    return `This action returns all orders`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} order`;
+  }
+
+  update(id: number, updateOrderDto: UpdateOrderDto) {
+    return `This action updates a #${id} order`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} order`;
+  }
+}

--- a/backend/src/positions/dto/create-position.dto.ts
+++ b/backend/src/positions/dto/create-position.dto.ts
@@ -1,0 +1,1 @@
+export class CreatePositionDto {}

--- a/backend/src/positions/dto/update-position.dto.ts
+++ b/backend/src/positions/dto/update-position.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreatePositionDto } from './create-position.dto';
+
+export class UpdatePositionDto extends PartialType(CreatePositionDto) {}

--- a/backend/src/positions/entities/position.entity.ts
+++ b/backend/src/positions/entities/position.entity.ts
@@ -1,0 +1,50 @@
+// backend/src/positions/entities/position.entity.ts
+
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { PositionSide } from '../../common/enums/order.enum';
+
+@Entity({ name: 'positions' })
+export class Position {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => User, (user) => user.id, { eager: false })
+  user: User;
+
+  @Column()
+  symbol: string;
+
+  // side가 LONG이면, (현재가 - 진입가) * 수량으로 PNL을 계산
+  // side가 SHORT이면, (진입가 - 현재가) * 수량으로 PNL을 계산
+  @Column({ type: 'enum', enum: PositionSide })
+  side: PositionSide;
+
+  @Column({ type: 'decimal', precision: 20, scale: 10 })
+  quantity: number; // 포지션 규모
+
+  @Column({ type: 'decimal', precision: 20, scale: 10 })
+  entryPrice: number; // 진입 가격
+
+  @Column({ type: 'decimal', precision: 20, scale: 10 })
+  liquidationPrice: number; // 청산 가격
+
+  @Column({ type: 'int' })
+  leverage: number; // 레버리지
+
+  @Column({ type: 'decimal', precision: 20, scale: 10 })
+  margin: number; // 증거금 (실제 투입된 내 돈) = 담보
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/positions/positions.controller.ts
+++ b/backend/src/positions/positions.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { PositionsService } from './positions.service';
+import { CreatePositionDto } from './dto/create-position.dto';
+import { UpdatePositionDto } from './dto/update-position.dto';
+
+@Controller('positions')
+export class PositionsController {
+  constructor(private readonly positionsService: PositionsService) {}
+
+  @Post()
+  create(@Body() createPositionDto: CreatePositionDto) {
+    return this.positionsService.create(createPositionDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.positionsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.positionsService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updatePositionDto: UpdatePositionDto) {
+    return this.positionsService.update(+id, updatePositionDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.positionsService.remove(+id);
+  }
+}

--- a/backend/src/positions/positions.module.ts
+++ b/backend/src/positions/positions.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { PositionsService } from './positions.service';
+import { PositionsController } from './positions.controller';
+
+@Module({
+  controllers: [PositionsController],
+  providers: [PositionsService],
+})
+export class PositionsModule {}

--- a/backend/src/positions/positions.service.ts
+++ b/backend/src/positions/positions.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreatePositionDto } from './dto/create-position.dto';
+import { UpdatePositionDto } from './dto/update-position.dto';
+
+@Injectable()
+export class PositionsService {
+  create(createPositionDto: CreatePositionDto) {
+    return 'This action adds a new position';
+  }
+
+  findAll() {
+    return `This action returns all positions`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} position`;
+  }
+
+  update(id: number, updatePositionDto: UpdatePositionDto) {
+    return `This action updates a #${id} position`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} position`;
+  }
+}

--- a/backend/src/transactions/dto/create-transaction.dto.ts
+++ b/backend/src/transactions/dto/create-transaction.dto.ts
@@ -1,0 +1,1 @@
+export class CreateTransactionDto {}

--- a/backend/src/transactions/dto/update-transaction.dto.ts
+++ b/backend/src/transactions/dto/update-transaction.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateTransactionDto } from './create-transaction.dto';
+
+export class UpdateTransactionDto extends PartialType(CreateTransactionDto) {}

--- a/backend/src/transactions/entities/transaction.entity.ts
+++ b/backend/src/transactions/entities/transaction.entity.ts
@@ -1,0 +1,38 @@
+// backend/src/transactions/entities/transaction.entity.ts
+// 모든 '돈'의 흐름을 기록하는 매우 중요한 장부
+// Wallet(지갑)의 잔고가 왜, 얼마만큼 변했는지에 대한 모든 역사를 추적하는 역할
+
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Wallet } from '../../wallets/entities/wallet.entity';
+
+export enum TransactionType {
+  DEPOSIT = 'DEPOSIT', // 입금
+  WITHDRAW = 'WITHDRAW', // 출금
+  REALIZED_PNL = 'REALIZED_PNL', // 실현 손익
+  FEE = 'FEE', // 수수료
+}
+
+@Entity({ name: 'transactions' })
+export class Transaction {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  // "하나의 지갑(Wallet)에는 여러 개의 거래 내역(Transaction)이 있을 수 있다"는 관계
+  @ManyToOne(() => Wallet, (wallet) => wallet.id)
+  wallet: Wallet;
+
+  @Column({ type: 'enum', enum: TransactionType })
+  type: TransactionType;
+
+  @Column({ type: 'decimal', precision: 20, scale: 4 })
+  amount: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/transactions/transactions.controller.ts
+++ b/backend/src/transactions/transactions.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { TransactionsService } from './transactions.service';
+import { CreateTransactionDto } from './dto/create-transaction.dto';
+import { UpdateTransactionDto } from './dto/update-transaction.dto';
+
+@Controller('transactions')
+export class TransactionsController {
+  constructor(private readonly transactionsService: TransactionsService) {}
+
+  @Post()
+  create(@Body() createTransactionDto: CreateTransactionDto) {
+    return this.transactionsService.create(createTransactionDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.transactionsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.transactionsService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateTransactionDto: UpdateTransactionDto) {
+    return this.transactionsService.update(+id, updateTransactionDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.transactionsService.remove(+id);
+  }
+}

--- a/backend/src/transactions/transactions.module.ts
+++ b/backend/src/transactions/transactions.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TransactionsService } from './transactions.service';
+import { TransactionsController } from './transactions.controller';
+
+@Module({
+  controllers: [TransactionsController],
+  providers: [TransactionsService],
+})
+export class TransactionsModule {}

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateTransactionDto } from './dto/create-transaction.dto';
+import { UpdateTransactionDto } from './dto/update-transaction.dto';
+
+@Injectable()
+export class TransactionsService {
+  create(createTransactionDto: CreateTransactionDto) {
+    return 'This action adds a new transaction';
+  }
+
+  findAll() {
+    return `This action returns all transactions`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} transaction`;
+  }
+
+  update(id: number, updateTransactionDto: UpdateTransactionDto) {
+    return `This action updates a #${id} transaction`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} transaction`;
+  }
+}

--- a/backend/src/wallets/dto/create-wallet.dto.ts
+++ b/backend/src/wallets/dto/create-wallet.dto.ts
@@ -1,0 +1,1 @@
+export class CreateWalletDto {}

--- a/backend/src/wallets/dto/update-wallet.dto.ts
+++ b/backend/src/wallets/dto/update-wallet.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateWalletDto } from './create-wallet.dto';
+
+export class UpdateWalletDto extends PartialType(CreateWalletDto) {}

--- a/backend/src/wallets/entities/wallet.entity.ts
+++ b/backend/src/wallets/entities/wallet.entity.ts
@@ -1,0 +1,24 @@
+// backend/src/wallets/entities/wallet.entity.ts
+
+import { User } from '../../users/entities/user.entity';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity({ name: 'wallets' })
+export class Wallet {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  // User(1) : Wallet(1) 관계 설정
+  @OneToOne(() => User, { eager: false })
+  @JoinColumn() // JoinColumn은 OneToOne 관계에서 주인이 되는 쪽에 붙임
+  user: User;
+
+  @Column({ type: 'decimal', precision: 20, scale: 4, default: 0.0 })
+  balance: number; // 지갑 잔액
+}

--- a/backend/src/wallets/wallets.controller.ts
+++ b/backend/src/wallets/wallets.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { WalletsService } from './wallets.service';
+import { CreateWalletDto } from './dto/create-wallet.dto';
+import { UpdateWalletDto } from './dto/update-wallet.dto';
+
+@Controller('wallets')
+export class WalletsController {
+  constructor(private readonly walletsService: WalletsService) {}
+
+  @Post()
+  create(@Body() createWalletDto: CreateWalletDto) {
+    return this.walletsService.create(createWalletDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.walletsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.walletsService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateWalletDto: UpdateWalletDto) {
+    return this.walletsService.update(+id, updateWalletDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.walletsService.remove(+id);
+  }
+}

--- a/backend/src/wallets/wallets.module.ts
+++ b/backend/src/wallets/wallets.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { WalletsService } from './wallets.service';
+import { WalletsController } from './wallets.controller';
+
+@Module({
+  controllers: [WalletsController],
+  providers: [WalletsService],
+})
+export class WalletsModule {}

--- a/backend/src/wallets/wallets.service.ts
+++ b/backend/src/wallets/wallets.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { CreateWalletDto } from './dto/create-wallet.dto';
+import { UpdateWalletDto } from './dto/update-wallet.dto';
+
+@Injectable()
+export class WalletsService {
+  create(createWalletDto: CreateWalletDto) {
+    return 'This action adds a new wallet';
+  }
+
+  findAll() {
+    return `This action returns all wallets`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} wallet`;
+  }
+
+  update(id: number, updateWalletDto: UpdateWalletDto) {
+    return `This action updates a #${id} wallet`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} wallet`;
+  }
+}


### PR DESCRIPTION
## 📝 작업 내용 (Description)

백엔드에서 사용자의 주문, 포지션, 자산 정보를 관리하기 위한 데이터베이스 테이블 스키마를 설계하고, 이에 맞는 TypeORM 엔티티(Entity)들을 생성했습니다.

<br>

## ✅ 관련 이슈 (Related Issues)

- Closes #7 

<br>

## ✨ 변경점 (Changes)

- [x] **`Order` 엔티티 추가:** 사용자의 모든 주문 기록을 저장합니다.
- [x] **`Position` 엔티티 추가:** 현재 보유 중인 미청산 포지션 정보를 저장합니다.
- [x] **`Wallet` 엔티티 추가:** 사용자의 모의 자산 잔고를 관리합니다.
- [x] **`Transaction` 엔티티 추가:** 모든 자산 변동 내역(실현 손익, 수수료 등)을 기록합니다.
- [x] **공통 `Enum` 타입 정의:** `OrderType`, `PositionSide` 등 재사용 가능한 상수들을 Enum으로 관리합니다.
- [x] `AppModule`에 신규 모듈 및 엔티티 등록을 완료했습니다.

<br>

---

### Self-Checklist

- [x] `develop` 브랜치로 PR을 요청합니다.
- [x] PR 제목에 작업 유형을 명시했습니다. (예: `feat:`, `fix:`)