### PR TITLE
feat(backend): Implement market order API and mock engine #8

### DIFF
--- a/backend/src/auth/guards/jwt-auth.guard.ts
+++ b/backend/src/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,6 @@
+// backend/src/auth/guards/jwt-auth.guard.ts
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {} // 'jwt'는 JwtStrategy를 지칭

--- a/backend/src/orders/dto/create-order.dto.ts
+++ b/backend/src/orders/dto/create-order.dto.ts
@@ -1,1 +1,28 @@
-export class CreateOrderDto {}
+// backend/src/orders/dto/create-order.dto.ts
+
+import { IsEnum, IsNumber, IsString, Min } from 'class-validator';
+import { OrderSide, OrderType } from '../../common/enums/order.enum';
+
+export class CreateOrderDto {
+  @IsString()
+  symbol: string;
+
+  @IsEnum(OrderType)
+  type: OrderType;
+
+  @IsEnum(OrderSide)
+  side: OrderSide;
+
+  // 지정가(LIMIT) 주문일 때만 필요한 값이므로, @IsOptional() 데코레이터를 사용할 수도 있지만
+  // 일단은 필수 값으로 두고 서비스 로직에서 분기 처리하겠습니다.
+  @IsNumber()
+  price: number; // 시장가 주문 시에는 0 또는 클라이언트에서 보내지 않음
+
+  @IsNumber()
+  @Min(0.00001) // 최소 주문 수량 제약
+  quantity: number;
+
+  @IsNumber()
+  @Min(1)
+  leverage: number;
+}

--- a/backend/src/orders/orders.controller.ts
+++ b/backend/src/orders/orders.controller.ts
@@ -1,34 +1,17 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Post, Body, UseGuards, Request } from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-order.dto';
-import { UpdateOrderDto } from './dto/update-order.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @Controller('orders')
 export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}
 
+  @UseGuards(JwtAuthGuard) // 👈 이 API는 JWT 인증이 필요함을 명시
   @Post()
-  create(@Body() createOrderDto: CreateOrderDto) {
-    return this.ordersService.create(createOrderDto);
-  }
-
-  @Get()
-  findAll() {
-    return this.ordersService.findAll();
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.ordersService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateOrderDto: UpdateOrderDto) {
-    return this.ordersService.update(+id, updateOrderDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.ordersService.remove(+id);
+  create(@Body() createOrderDto: CreateOrderDto, @Request() req) {
+    // req.user에는 JwtStrategy의 validate 메소드가 반환한 user 객체가 담겨 있음
+    const userId = req.user.id;
+    return this.ordersService.createOrder(userId, createOrderDto);
   }
 }

--- a/backend/src/orders/orders.module.ts
+++ b/backend/src/orders/orders.module.ts
@@ -1,8 +1,13 @@
 import { Module } from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { OrdersController } from './orders.controller';
+import { WalletsModule } from '../wallets/wallets.module';
+import { PositionsModule } from '../positions/positions.module';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Order } from './entities/order.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Order]), WalletsModule, PositionsModule],
   controllers: [OrdersController],
   providers: [OrdersService],
 })

--- a/backend/src/orders/orders.service.ts
+++ b/backend/src/orders/orders.service.ts
@@ -1,26 +1,82 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { CreateOrderDto } from './dto/create-order.dto';
-import { UpdateOrderDto } from './dto/update-order.dto';
+import { Order } from './entities/order.entity';
+import {
+  OrderSide,
+  OrderStatus,
+  OrderType,
+  PositionSide,
+} from '../common/enums/order.enum';
+import { PositionsService } from '../positions/positions.service';
+import { WalletsService } from '../wallets/wallets.service';
 
 @Injectable()
 export class OrdersService {
-  create(createOrderDto: CreateOrderDto) {
-    return 'This action adds a new order';
-  }
+  constructor(
+    @InjectRepository(Order)
+    private readonly ordersRepository: Repository<Order>,
+    private readonly positionsService: PositionsService,
+    private readonly walletsService: WalletsService,
+    // TODO: 나중에 BinanceApiService도 주입받아 실제 시장가를 가져와야 함
+  ) {}
 
-  findAll() {
-    return `This action returns all orders`;
-  }
+  async createOrder(userId: string, createOrderDto: CreateOrderDto) {
+    // 지금은 시장가(MARKET) 주문만 처리
+    if (createOrderDto.type !== OrderType.MARKET) {
+      throw new BadRequestException('지정가 주문은 현재 지원되지 않습니다.');
+    }
 
-  findOne(id: number) {
-    return `This action returns a #${id} order`;
-  }
+    // --- 1. 모의 시장가 가져오기 ---
+    // TODO: 실제로는 BinanceApiService를 통해 현재 시장가를 가져와야 함
+    const mockMarketPrice = 50000.0; // 임시 모의 시장가
 
-  update(id: number, updateOrderDto: UpdateOrderDto) {
-    return `This action updates a #${id} order`;
-  }
+    const { symbol, side, quantity, leverage } = createOrderDto; // 종목, 방향, 수량, 레버리지
 
-  remove(id: number) {
-    return `This action removes a #${id} order`;
+    // --- 2. 필요한 증거금(margin) 계산 ---
+    // 총 거래대금 = (체결 가격) * (주문 수량), 즉 50000 * quantity
+    // 필요 증거금 = (총 거래대금) / (레버리지)
+    // 예: 10배 레버리지로 0.1 BTC (5,000달러어치)를 주문하면, 필요한 내 돈은 500달러
+    const marginRequired = (mockMarketPrice * quantity) / leverage;
+
+    // --- 3. 사용자 지갑 잔고 확인 ---
+    const hasSufficientBalance = await this.walletsService.checkBalance(
+      userId,
+      marginRequired,
+    );
+    if (!hasSufficientBalance) {
+      throw new BadRequestException('증거금이 부족합니다.');
+    }
+
+    // --- 4. 주문(Order) 기록 생성 ---
+    const newOrder = this.ordersRepository.create({
+      user: { id: userId }, // 관계형 데이터는 id만 넣어줘도 됨
+      symbol,
+      type: OrderType.MARKET,
+      side,
+      price: mockMarketPrice, // 체결된 시장가로 기록
+      quantity,
+      status: OrderStatus.FILLED, // 시장가는 즉시 체결
+    });
+    await this.ordersRepository.save(newOrder);
+
+    // --- 5. 포지션(Position) 생성 또는 업데이트 ---
+    const positionSide =
+      side === OrderSide.BUY ? PositionSide.LONG : PositionSide.SHORT;
+    const newPosition = await this.positionsService.createOrUpdatePosition({
+      userId,
+      symbol,
+      side: positionSide,
+      quantity,
+      entryPrice: mockMarketPrice,
+      leverage,
+      margin: marginRequired,
+    });
+
+    // --- 6. 지갑 잔고에서 증거금 차감 ---
+    await this.walletsService.updateBalance(userId, -marginRequired);
+
+    return { order: newOrder, position: newPosition };
   }
 }

--- a/backend/src/positions/positions.module.ts
+++ b/backend/src/positions/positions.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { PositionsService } from './positions.service';
 import { PositionsController } from './positions.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Position } from './entities/position.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Position])],
   controllers: [PositionsController],
   providers: [PositionsService],
+  exports: [PositionsService],
 })
 export class PositionsModule {}

--- a/backend/src/positions/positions.service.ts
+++ b/backend/src/positions/positions.service.ts
@@ -1,26 +1,57 @@
 import { Injectable } from '@nestjs/common';
-import { CreatePositionDto } from './dto/create-position.dto';
-import { UpdatePositionDto } from './dto/update-position.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Position } from './entities/position.entity';
+import { PositionSide } from '../common/enums/order.enum';
+
+// createOrUpdatePosition 메소드에 전달될 데이터 타입을 정의
+interface PositionParams {
+  userId: string;
+  symbol: string;
+  side: PositionSide; // 사는거냐(BUY) 파는거냐(SELL)
+  quantity: number;
+  entryPrice: number;
+  leverage: number;
+  margin: number; // 주문 체결에 필요한 증거금
+}
 
 @Injectable()
 export class PositionsService {
-  create(createPositionDto: CreatePositionDto) {
-    return 'This action adds a new position';
-  }
+  constructor(
+    @InjectRepository(Position)
+    private readonly positionsRepository: Repository<Position>,
+  ) {}
 
-  findAll() {
-    return `This action returns all positions`;
-  }
+  async createOrUpdatePosition(params: PositionParams): Promise<Position> {
+    const { userId, symbol, side, quantity, entryPrice, leverage, margin } =
+      params;
 
-  findOne(id: number) {
-    return `This action returns a #${id} position`;
-  }
+    // 1. 동일한 종목, 동일한 방향의 기존 포지션이 있는지 확인
+    const existingPosition = await this.positionsRepository.findOne({
+      where: { user: { id: userId }, symbol, side },
+    });
 
-  update(id: number, updatePositionDto: UpdatePositionDto) {
-    return `This action updates a #${id} position`;
-  }
-
-  remove(id: number) {
-    return `This action removes a #${id} position`;
+    if (existingPosition) {
+      // 2. 기존 포지션이 있으면 '물타기/불타기' 로직 실행 (평균 단가, 수량 업데이트)
+      // TODO: 지금은 단순 덮어쓰기. 추후 평균 단가 계산 로직으로 고도화 필요
+      existingPosition.quantity += quantity;
+      existingPosition.margin += margin;
+      // entryPrice, liquidationPrice도 평균값으로 재계산 필요
+      return this.positionsRepository.save(existingPosition);
+    } else {
+      // 3. 기존 포지션이 없으면 새로 생성
+      // TODO: 청산 가격(liquidationPrice) 계산 로직 필요
+      const newPosition = this.positionsRepository.create({
+        user: { id: userId },
+        symbol,
+        side,
+        quantity,
+        entryPrice,
+        leverage,
+        margin,
+        liquidationPrice: 0, // 임시값
+      });
+      return this.positionsRepository.save(newPosition);
+    }
   }
 }

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -3,11 +3,12 @@
 import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
-import { TypeOrmModule } from '@nestjs/typeorm'; // 1. TypeOrmModule 임포트
-import { User } from './entities/user.entity'; // 2. User 엔티티 임포트
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './entities/user.entity';
+import { WalletsModule } from 'src/wallets/wallets.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])], // 3. User 엔티티를 TypeOrmModule에 등록
+  imports: [TypeOrmModule.forFeature([User]), WalletsModule],
   controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -7,6 +7,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateUserDto } from './dto/create-user.dto';
 import { User } from './entities/user.entity';
+import { WalletsService } from '../wallets/wallets.service';
 import * as bcrypt from 'bcrypt';
 
 // 서비스 메소드의 반환 타입을 명시적으로 정의 (비밀번호 제외)
@@ -20,6 +21,7 @@ export class UsersService {
     @InjectRepository(User)
     // usersRepository는 데이터베이스의 users 테이블과 직접적으로 소통하는 객체
     private readonly usersRepository: Repository<User>,
+    private readonly walletsService: WalletsService,
   ) {}
 
   /**
@@ -58,6 +60,9 @@ export class UsersService {
       // 하지만 우리가 정의한 반환 타입(UserWithoutPassword) 덕분에 최종 반환 시에는
       // password가 자동으로 제외(타입 체크)됩니다.
       const savedUser = await this.usersRepository.save(newUser);
+
+      // 사용자 생성 후, 해당 사용자의 지갑을 생성합니다.
+      await this.walletsService.createWallet(savedUser);
 
       // 반환하기 전에 명시적으로 password를 제거해주는 것이 가장 안전하고 확실합니다.
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/backend/src/wallets/wallets.module.ts
+++ b/backend/src/wallets/wallets.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
 import { WalletsService } from './wallets.service';
 import { WalletsController } from './wallets.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Wallet } from './entities/wallet.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Wallet])],
   controllers: [WalletsController],
   providers: [WalletsService],
+  exports: [WalletsService],
 })
 export class WalletsModule {}

--- a/backend/src/wallets/wallets.service.ts
+++ b/backend/src/wallets/wallets.service.ts
@@ -1,26 +1,70 @@
-import { Injectable } from '@nestjs/common';
-import { CreateWalletDto } from './dto/create-wallet.dto';
-import { UpdateWalletDto } from './dto/update-wallet.dto';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Wallet } from './entities/wallet.entity';
+import { User } from '../users/entities/user.entity';
 
 @Injectable()
 export class WalletsService {
-  create(createWalletDto: CreateWalletDto) {
-    return 'This action adds a new wallet';
+  constructor(
+    @InjectRepository(Wallet)
+    private readonly walletsRepository: Repository<Wallet>,
+  ) {}
+
+  /**
+   * 사용자의 지갑을 생성합니다. (회원가입 시 호출됨)
+   * @param user 새로 생성된 사용자 객체
+   * @param initialBalance 초기 잔액
+   * @returns 생성된 지갑 정보
+   */
+  async createWallet(user: User, initialBalance = 10000.0): Promise<Wallet> {
+    const wallet = this.walletsRepository.create({
+      user,
+      balance: initialBalance,
+    });
+    return this.walletsRepository.save(wallet);
   }
 
-  findAll() {
-    return `This action returns all wallets`;
+  /**
+   * 사용자의 잔고가 특정 금액 이상인지 확인합니다.
+   * @param userId 사용자 ID
+   * @param amount 필요한 금액
+   * @returns 잔고가 충분하면 true, 아니면 false
+   */
+  async checkBalance(userId: string, amount: number): Promise<boolean> {
+    const wallet = await this.findWalletByUserId(userId);
+    return wallet.balance >= amount;
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} wallet`;
+  /**
+   * 사용자의 지갑 잔고를 업데이트합니다.
+   * @param userId 사용자 ID
+   * @param amount 변경할 금액 (음수도 가능)
+   * @returns 업데이트된 지갑 정보
+   */
+  async updateBalance(userId: string, amount: number): Promise<Wallet> {
+    const wallet = await this.findWalletByUserId(userId);
+    // TypeORM은 decimal 타입을 string으로 다룰 수 있으므로, 숫자형으로 변환 후 계산
+    const newBalance = parseFloat(wallet.balance.toString()) + amount;
+
+    wallet.balance = newBalance;
+    return this.walletsRepository.save(wallet);
   }
 
-  update(id: number, updateWalletDto: UpdateWalletDto) {
-    return `This action updates a #${id} wallet`;
-  }
-
-  remove(id: number) {
-    return `This action removes a #${id} wallet`;
+  /**
+   * 사용자 ID로 지갑을 찾는 내부 헬퍼 메소드
+   * @param userId 사용자 ID
+   * @returns 지갑 객체
+   */
+  private async findWalletByUserId(userId: string): Promise<Wallet> {
+    const wallet = await this.walletsRepository.findOne({
+      where: { user: { id: userId } },
+    });
+    if (!wallet) {
+      throw new NotFoundException(
+        `User ID ${userId}에 대한 지갑을 찾을 수 없습니다.`,
+      );
+    }
+    return wallet;
   }
 }


### PR DESCRIPTION
## 📝 작업 내용 (Description)

사용자가 시장가(Market)로 신규 주문을 제출하고, 그 결과로 포지션이 생성되는 핵심 백엔드 API 및 로직을 구현했습니다.

<br>

## ✅ 관련 이슈 (Related Issues)

- Closes #8 

<br>

## ✨ 변경점 (Changes)

- **`POST /orders` API 엔드포인트 구현:**
  - `JwtAuthGuard`를 적용하여 로그인한 사용자만 주문할 수 있도록 보호합니다.
  - `CreateOrderDto`를 통해 주문 요청 데이터의 유효성을 검사합니다.
- **모의 체결 엔진 로직 개발 (`OrdersService`):**
  - 주문에 필요한 증거금(Margin)을 계산합니다.
  - `WalletsService`와 연동하여 사용자 지갑의 잔고를 확인하고, 주문 후 증거금을 차감합니다.
  - `PositionsService`와 연동하여 주문 체결 시 신규 포지션을 생성하거나 기존 포지션을 업데이트합니다.
  - 성공적으로 체결된 내용을 `orders` 테이블에 기록합니다.
- **헬퍼 서비스 메소드 추가:**
  - `WalletsService`: `checkBalance`, `updateBalance`, `createWallet` (회원가입 시) 메소드 추가
  - `PositionsService`: `createOrUpdatePosition` 메소드 추가
- **모듈 의존성 설정:**
  - `OrdersModule`, `UsersModule` 등이 `WalletsModule`, `PositionsModule`을 사용할 수 있도록 의존성을 설정했습니다.

<br>

---

### Self-Checklist

- [x] `develop` 브랜치로 PR을 요청합니다.
- [x] PR 제목에 작업 유형을 명시했습니다. (예: `feat:`, `fix:`)