### PR TITLE
feat(frontend): Implement OrderPanel with API integration #9

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,8 +1,30 @@
+// backend/src/main.ts
+
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common'; // ValidationPipe import 추가
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  await app.listen(process.env.PORT ?? 3001);
+
+  // --- CORS 설정 추가 ---
+  app.enableCors({
+    origin: 'http://localhost:5173', // 프론트엔드 주소만 명시적으로 허용
+    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+    credentials: true,
+  });
+
+  // 전역 ValidationPipe 추가 (DTO 유효성 검사를 위해)
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true, // DTO에 정의되지 않은 속성은 자동으로 제거
+      forbidNonWhitelisted: true, // DTO에 없는 속성이 들어오면 에러 발생
+      transform: true, // 요청 데이터를 DTO 타입으로 자동 변환
+    }),
+  );
+  // 포트 번호를 .env에서 가져오도록 수정
+  const port = process.env.PORT || 3001;
+  await app.listen(port);
+  console.log(`Application is running on: http://localhost:${port}`); // 실행 포트 로그 추가
 }
 void bootstrap();

--- a/backend/src/orders/dto/create-order.dto.ts
+++ b/backend/src/orders/dto/create-order.dto.ts
@@ -1,6 +1,13 @@
 // backend/src/orders/dto/create-order.dto.ts
 
-import { IsEnum, IsNumber, IsString, Min } from 'class-validator';
+import {
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+  ValidateIf,
+} from 'class-validator';
 import { OrderSide, OrderType } from '../../common/enums/order.enum';
 
 export class CreateOrderDto {
@@ -16,7 +23,10 @@ export class CreateOrderDto {
   // 지정가(LIMIT) 주문일 때만 필요한 값이므로, @IsOptional() 데코레이터를 사용할 수도 있지만
   // 일단은 필수 값으로 두고 서비스 로직에서 분기 처리하겠습니다.
   @IsNumber()
-  price: number; // 시장가 주문 시에는 0 또는 클라이언트에서 보내지 않음
+  @IsOptional() // price 필드는 이제 선택 사항(Optional)입니다.
+  // o.type이 'LIMIT'일 경우에만 아래 유효성 검사를 실행합니다.
+  @ValidateIf((o) => o.type === OrderType.LIMIT)
+  price?: number; // 시장가(MARKET) 주문 시에는 이 값이 없을 수 있으므로 '?' 추가
 
   @IsNumber()
   @Min(0.00001) // 최소 주문 수량 제약

--- a/backend/src/positions/positions.controller.ts
+++ b/backend/src/positions/positions.controller.ts
@@ -1,34 +1,7 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller } from '@nestjs/common';
 import { PositionsService } from './positions.service';
-import { CreatePositionDto } from './dto/create-position.dto';
-import { UpdatePositionDto } from './dto/update-position.dto';
 
 @Controller('positions')
 export class PositionsController {
   constructor(private readonly positionsService: PositionsService) {}
-
-  @Post()
-  create(@Body() createPositionDto: CreatePositionDto) {
-    return this.positionsService.create(createPositionDto);
-  }
-
-  @Get()
-  findAll() {
-    return this.positionsService.findAll();
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.positionsService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updatePositionDto: UpdatePositionDto) {
-    return this.positionsService.update(+id, updatePositionDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.positionsService.remove(+id);
-  }
 }

--- a/backend/src/positions/positions.service.ts
+++ b/backend/src/positions/positions.service.ts
@@ -32,11 +32,23 @@ export class PositionsService {
     });
 
     if (existingPosition) {
-      // 2. 기존 포지션이 있으면 '물타기/불타기' 로직 실행 (평균 단가, 수량 업데이트)
-      // TODO: 지금은 단순 덮어쓰기. 추후 평균 단가 계산 로직으로 고도화 필요
-      existingPosition.quantity += quantity;
-      existingPosition.margin += margin;
-      // entryPrice, liquidationPrice도 평균값으로 재계산 필요
+      // --- 여기가 수정될 부분입니다 ---
+      // 1. 기존 값들을 명시적으로 숫자로 변환합니다.
+      const existingQuantity = Number(existingPosition.quantity);
+      const existingMargin = Number(existingPosition.margin);
+
+      // 2. 새로운 값(수량, 증거금)을 계산합니다.
+      const newQuantity = existingQuantity + quantity;
+      const newMargin = existingMargin + margin;
+
+      // TODO: 추후 평균 진입 가격(entryPrice) 재계산 로직 추가 필요
+      // const totalValue = (existingQuantity * existingPosition.entryPrice) + (quantity * entryPrice);
+      // existingPosition.entryPrice = totalValue / newQuantity;
+
+      // 3. 계산된 숫자 값을 할당합니다.
+      existingPosition.quantity = newQuantity;
+      existingPosition.margin = newMargin;
+
       return this.positionsRepository.save(existingPosition);
     } else {
       // 3. 기존 포지션이 없으면 새로 생성

--- a/backend/src/wallets/wallets.controller.ts
+++ b/backend/src/wallets/wallets.controller.ts
@@ -1,34 +1,7 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller } from '@nestjs/common';
 import { WalletsService } from './wallets.service';
-import { CreateWalletDto } from './dto/create-wallet.dto';
-import { UpdateWalletDto } from './dto/update-wallet.dto';
 
 @Controller('wallets')
 export class WalletsController {
   constructor(private readonly walletsService: WalletsService) {}
-
-  @Post()
-  create(@Body() createWalletDto: CreateWalletDto) {
-    return this.walletsService.create(createWalletDto);
-  }
-
-  @Get()
-  findAll() {
-    return this.walletsService.findAll();
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.walletsService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateWalletDto: UpdateWalletDto) {
-    return this.walletsService.update(+id, updateWalletDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.walletsService.remove(+id);
-  }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.10.0",
         "lightweight-charts": "^4.1.0",
         "lodash.debounce": "^4.0.8",
         "react": "^19.1.0",
@@ -1870,6 +1871,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1932,6 +1950,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -2010,6 +2041,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2100,6 +2143,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.177",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.177.tgz",
@@ -2144,6 +2210,51 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -2519,6 +2630,42 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2534,6 +2681,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2542,6 +2698,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -2570,6 +2763,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2585,6 +2790,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -2813,6 +3057,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2835,6 +3088,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -3034,6 +3308,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.10.0",
     "lightweight-charts": "^4.1.0",
     "lodash.debounce": "^4.0.8",
     "react": "^19.1.0",

--- a/frontend/src/components/OrderPanel/index.tsx
+++ b/frontend/src/components/OrderPanel/index.tsx
@@ -1,0 +1,103 @@
+// frontend/src/components/OrderPanel/index.tsx
+
+import { useState } from "react";
+import * as S from "./styles";
+
+// 나중에 API 서비스를 통해 가져올 타입들 (임시 정의)
+interface OrderPayload {
+  symbol: string;
+  type: "MARKET" | "LIMIT";
+  side: "BUY" | "SELL";
+  quantity: number;
+  leverage: number;
+  price?: number; // 지정가 주문을 위해 옵셔널
+}
+
+const OrderPanel = () => {
+  // 'BUY'(롱) 또는 'SELL'(숏)을 관리하는 상태
+  const [positionSide, setPositionSide] = useState<"BUY" | "SELL">("BUY");
+  // 수량 입력 (BTC)
+  const [quantity, setQuantity] = useState("");
+  // 레버리지
+  const [leverage, setLeverage] = useState(1);
+  // 현재는 시장가 주문만 구현
+  const orderType = "MARKET";
+  const symbol = "BTCUSDT"; // 지금은 BTCUSDT로 고정
+
+  // 주문 제출 핸들러 (API 연동 전, 콘솔 출력)
+  const handleSubmit = () => {
+    const numQuantity = parseFloat(quantity);
+    if (isNaN(numQuantity) || numQuantity <= 0) {
+      alert("정확한 수량을 입력해주세요.");
+      return;
+    }
+
+    const payload: OrderPayload = {
+      symbol,
+      type: orderType,
+      side: positionSide,
+      quantity: numQuantity,
+      leverage: leverage,
+    };
+
+    // TODO: Step 3에서 실제 API 연동 로직으로 교체될 부분입니다.
+    console.log("Submitting Order:", payload);
+    alert(`주문 제출: ${JSON.stringify(payload)}`);
+  };
+
+  return (
+    <S.OrderPanelContainer>
+      <S.TabWrapper>
+        <S.TabButton
+          active={positionSide === "BUY"}
+          onClick={() => setPositionSide("BUY")}
+        >
+          롱 (매수)
+        </S.TabButton>
+        <S.TabButton
+          active={positionSide === "SELL"}
+          onClick={() => setPositionSide("SELL")}
+        >
+          숏 (매도)
+        </S.TabButton>
+      </S.TabWrapper>
+
+      <S.Form>
+        <S.InputGroup>
+          <label htmlFor="leverage">레버리지 ({leverage}x)</label>
+          <S.LeverageSlider
+            type="range"
+            id="leverage"
+            min="1"
+            max="50"
+            value={leverage}
+            onChange={(e) => setLeverage(parseInt(e.target.value, 10))}
+          />
+        </S.InputGroup>
+
+        <S.InputGroup>
+          <label htmlFor="quantity">수량 ({symbol.replace("USDT", "")})</label>
+          <S.Input
+            type="number"
+            id="quantity"
+            value={quantity}
+            onChange={(e) => setQuantity(e.target.value)}
+            placeholder="0.00"
+          />
+        </S.InputGroup>
+
+        <S.InfoGroup>
+          <span>주문 가능 금액:</span>
+          {/* TODO: 이슈 #10에서 실제 지갑 정보와 연동됩니다. */}
+          <span>10000.00 USDT</span>
+        </S.InfoGroup>
+      </S.Form>
+
+      <S.SubmitButton side={positionSide} onClick={handleSubmit}>
+        {positionSide === "BUY" ? "롱 포지션 진입" : "숏 포지션 진입"}
+      </S.SubmitButton>
+    </S.OrderPanelContainer>
+  );
+};
+
+export default OrderPanel;

--- a/frontend/src/components/OrderPanel/index.tsx
+++ b/frontend/src/components/OrderPanel/index.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import * as S from "./styles";
+import { createOrder } from '../../services/orderService'; 
 
 // 나중에 API 서비스를 통해 가져올 타입들 (임시 정의)
 interface OrderPayload {
@@ -20,12 +21,17 @@ const OrderPanel = () => {
   const [quantity, setQuantity] = useState("");
   // 레버리지
   const [leverage, setLeverage] = useState(1);
+
+  // 로딩 및 에러 상태 관리를 위한 상태 추가
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
   // 현재는 시장가 주문만 구현
   const orderType = "MARKET";
   const symbol = "BTCUSDT"; // 지금은 BTCUSDT로 고정
 
   // 주문 제출 핸들러 (API 연동 전, 콘솔 출력)
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const numQuantity = parseFloat(quantity);
     if (isNaN(numQuantity) || numQuantity <= 0) {
       alert("정확한 수량을 입력해주세요.");
@@ -40,9 +46,32 @@ const OrderPanel = () => {
       leverage: leverage,
     };
 
-    // TODO: Step 3에서 실제 API 연동 로직으로 교체될 부분입니다.
-    console.log("Submitting Order:", payload);
-    alert(`주문 제출: ${JSON.stringify(payload)}`);
+        setIsLoading(true); // 로딩 시작
+    setError(null); // 이전 에러 메시지 초기화
+
+    try {
+      // 실제 API 호출
+      const response = await createOrder(payload);
+      console.log('Order created successfully:', response);
+      alert('주문이 성공적으로 체결되었습니다.');
+      
+      // 성공 시 입력 필드 초기화
+      setQuantity('');
+
+    } catch (err: unknown) {
+      // 서비스에서 던진 에러를 잡아서 상태에 저장
+      if (err instanceof Error) {
+        setError(err.message);
+        console.error(err.message);
+        alert(`오류: ${err.message}`); // 사용자에게 오류 피드백
+      } else {
+        setError('알 수 없는 오류가 발생했습니다.');
+        alert('알 수 없는 오류가 발생했습니다.');
+      }
+    } finally {
+      setIsLoading(false); // 로딩 종료 (성공/실패 모두)
+    }
+
   };
 
   return (
@@ -72,6 +101,7 @@ const OrderPanel = () => {
             max="50"
             value={leverage}
             onChange={(e) => setLeverage(parseInt(e.target.value, 10))}
+            disabled={isLoading}
           />
         </S.InputGroup>
 
@@ -83,6 +113,7 @@ const OrderPanel = () => {
             value={quantity}
             onChange={(e) => setQuantity(e.target.value)}
             placeholder="0.00"
+            disabled={isLoading}
           />
         </S.InputGroup>
 
@@ -93,8 +124,12 @@ const OrderPanel = () => {
         </S.InfoGroup>
       </S.Form>
 
-      <S.SubmitButton side={positionSide} onClick={handleSubmit}>
-        {positionSide === "BUY" ? "롱 포지션 진입" : "숏 포지션 진입"}
+      {/* 에러 메시지 표시 영역 추가 */}
+      {error && <S.ErrorMessage>{error}</S.ErrorMessage>}
+
+      <S.SubmitButton side={positionSide} onClick={handleSubmit} disabled={isLoading}>
+        {/* 로딩 상태에 따라 버튼 텍스트 변경 */}
+        {isLoading ? '주문 처리 중...' : (positionSide === 'BUY' ? '롱 포지션 진입' : '숏 포지션 진입')}
       </S.SubmitButton>
     </S.OrderPanelContainer>
   );

--- a/frontend/src/components/OrderPanel/styles.ts
+++ b/frontend/src/components/OrderPanel/styles.ts
@@ -113,6 +113,14 @@ export const InfoGroup = styled.div`
   padding: 8px 0;
 `;
 
+export const ErrorMessage = styled.p`
+  color: #f23645; // 숏 포지션(매도)과 동일한 빨간색
+  font-size: 12px;
+  text-align: center;
+  margin: 10px 0 0; // 위쪽 여백 추가
+  min-height: 15px; // 에러가 없을 때도 공간을 차지하도록 하여 레이아웃 밀림 방지
+`;
+
 export const SubmitButton = styled.button<{ side: 'BUY' | 'SELL' }>`
   margin-top: auto;
   padding: 14px;
@@ -127,5 +135,9 @@ export const SubmitButton = styled.button<{ side: 'BUY' | 'SELL' }>`
 
   &:hover {
     opacity: 0.9;
+  }
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 `;

--- a/frontend/src/components/OrderPanel/styles.ts
+++ b/frontend/src/components/OrderPanel/styles.ts
@@ -1,0 +1,131 @@
+// frontend/src/components/OrderPanel/styles.ts
+
+import styled from 'styled-components';
+
+export const OrderPanelContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  background-color: #1e222d;
+  color: #f0f0f0;
+  padding: 16px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  height: 100%;
+  box-sizing: border-box;
+`;
+
+export const TabWrapper = styled.div`
+  display: flex;
+  border-bottom: 1px solid #2a2e39;
+  margin-bottom: 16px;
+`;
+
+export const TabButton = styled.button<{ active: boolean }>`
+  flex: 1;
+  padding: 12px;
+  background: transparent;
+  border: none;
+  color: ${({ active }) => (active ? '#f0f0f0' : '#888')};
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  border-bottom: 2px solid ${({ active, children }) =>
+    active ? (children?.toString().includes('롱') ? '#089981' : '#f23645') : 'transparent'};
+  transition: all 0.2s ease-in-out;
+
+  &:hover {
+    color: #f0f0f0;
+  }
+`;
+
+export const Form = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  flex-grow: 1;
+`;
+
+export const InputGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  label {
+    font-size: 12px;
+    color: #888;
+    margin-bottom: 8px;
+  }
+`;
+
+export const Input = styled.input`
+  background-color: #2a2e39;
+  border: 1px solid #444;
+  color: #f0f0f0;
+  padding: 10px;
+  border-radius: 4px;
+  font-size: 14px;
+  width: 100%;
+  box-sizing: border-box;
+  -moz-appearance: textfield;
+
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  &:focus {
+    outline: none;
+    border-color: #5570ff;
+  }
+`;
+
+export const LeverageSlider = styled(Input)`
+  padding: 0;
+  height: 4px;
+  -webkit-appearance: none;
+  background: #444;
+  outline: none;
+  cursor: pointer;
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 16px;
+    height: 16px;
+    background: #5570ff;
+    border-radius: 50%;
+  }
+
+  &::-moz-range-thumb {
+    width: 16px;
+    height: 16px;
+    background: #5570ff;
+    border-radius: 50%;
+    cursor: pointer;
+  }
+`;
+
+
+export const InfoGroup = styled.div`
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: #aaa;
+  padding: 8px 0;
+`;
+
+export const SubmitButton = styled.button<{ side: 'BUY' | 'SELL' }>`
+  margin-top: auto;
+  padding: 14px;
+  border: none;
+  border-radius: 4px;
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: bold;
+  cursor: pointer;
+  background-color: ${({ side }) => (side === 'BUY' ? '#089981' : '#f23645')};
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 0.9;
+  }
+`;

--- a/frontend/src/pages/TradingPage.tsx
+++ b/frontend/src/pages/TradingPage.tsx
@@ -1,13 +1,14 @@
 // frontend/src/pages/TradingPage.tsx
 
-import styled from 'styled-components';
-import { TradingChart } from '../components/TradingChart'; // 차트 컴포넌트는 곧 생성
+import styled from "styled-components";
+import { TradingChart } from "../components/TradingChart";
+import OrderPanel from "../components/OrderPanel";
 
 const TradingPageContainer = styled.div`
   display: grid;
   grid-template-areas:
-    'chart order-panel'
-    'chart order-book';
+    "chart order-panel"
+    "chart order-book";
   grid-template-columns: 3fr 1fr; /* 차트가 3, 오른쪽 패널이 1의 비율 */
   grid-template-rows: 1fr 1fr;
   height: 95vh;
@@ -40,7 +41,9 @@ export const TradingPage = () => {
       <ChartContainer>
         <TradingChart />
       </ChartContainer>
-      <OrderPanelContainer>주문 패널</OrderPanelContainer>
+      <OrderPanelContainer>
+        <OrderPanel />
+      </OrderPanelContainer>
       <OrderBookContainer>호가창</OrderBookContainer>
     </TradingPageContainer>
   );

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,33 @@
+// frontend/src/services/api.ts
+
+import axios from "axios";
+
+const API_BASE_URL = "http://localhost:3001"; // 백엔드 서버 주소
+
+// Axios 인스턴스 생성
+const apiClient = axios.create({
+  baseURL: API_BASE_URL,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+// 요청 인터셉터 설정 (API 요청을 보내기 전에 실행)
+apiClient.interceptors.request.use(
+  (config) => {
+    // 로컬 스토리지 등에서 JWT 토큰을 가져옵니다.
+    // TODO: 로그인 기능 구현 후 실제 토큰으로 교체해야 합니다.
+    const token = localStorage.getItem("accessToken");
+
+    if (token) {
+      // 토큰이 있으면 Authorization 헤더에 Bearer 토큰을 추가합니다.
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+export default apiClient;

--- a/frontend/src/services/orderService.ts
+++ b/frontend/src/services/orderService.ts
@@ -1,0 +1,51 @@
+// frontend/src/services/orderService.ts
+
+import axios from "axios";
+import apiClient from "./api";
+
+// 백엔드의 CreateOrderDto와 타입을 맞춥니다.
+export interface OrderPayload {
+  symbol: string;
+  type: "MARKET" | "LIMIT";
+  side: "BUY" | "SELL";
+  quantity: number;
+  leverage: number;
+  price?: number;
+}
+
+// 백엔드의 응답 데이터 타입을 정의합니다. (실제 응답에 맞게 수정 필요)
+interface OrderResponse {
+  order: {
+    id: string;
+    // ... 기타 주문 정보
+  };
+  position: {
+    id: string;
+    // ... 기타 포지션 정보
+  };
+}
+
+/**
+ * 신규 주문을 생성합니다.
+ * @param orderData 주문 생성에 필요한 데이터
+ * @returns 생성된 주문 및 포지션 정보
+ */
+export const createOrder = async (
+  orderData: OrderPayload
+): Promise<OrderResponse> => {
+  try {
+    const response = await apiClient.post<OrderResponse>("/orders", orderData);
+    return response.data;
+  } catch (error) {
+    // Axios 에러 객체에서 더 구체적인 오류 메시지를 추출합니다.
+    if (axios.isAxiosError(error) && error.response) {
+      console.error("Order creation failed:", error.response.data);
+      // 서버에서 보낸 에러 메시지를 그대로 던져서 UI단에서 처리할 수 있게 합니다.
+      throw new Error(
+        error.response.data.message || "주문 생성에 실패했습니다."
+      );
+    }
+    console.error("An unexpected error occurred:", error);
+    throw new Error("알 수 없는 오류가 발생했습니다.");
+  }
+};


### PR DESCRIPTION
## 📝 작업 내용 (Description)

프론트엔드 주문 패널(Order Panel) UI 구현 및 백엔드 신규 주문 API 연동.
사용자의 시장가 주문(롱/숏) 기능 구현 완료.

<br>

## ✅ 관련 이슈 (Related Issues)

- Closes #9 

<br>

## ✨ 변경점 (Changes)

- **프론트엔드:**
    - `OrderPanel` UI 컴포넌트 및 스타일(styled-components) 구현.
    - 주문 관련 상태 관리 로직(주문 유형, 수량, 레버리지) 추가.
    - API 통신용 `axios` 라이브러리 설치 및 클라이언트 인스턴스 생성.
    - `orderService`에 신규 주문 생성(`createOrder`) 함수 구현.
    - `OrderPanel`에 API 호출, 로딩 및 에러 처리 로직 연동 완료.
- **백엔드 (수정사항):**
    - `main.ts`에 CORS 정책 및 전역 `ValidationPipe` 설정 추가.
    - `CreateOrderDto`의 `price` 필드 유효성 검사 로직 수정 (시장가 주문 지원).
    - `PositionsService`의 포지션 업데이트 시 `decimal` 값 계산 오류 수정.
    - 미사용 컨트롤러(`PositionsController`, `WalletsController`)의 기본 CRUD 메소드 제거.

<br>

---

### Self-Checklist

- [x] `develop` 브랜치로 PR을 요청합니다.
- [x] PR 제목에 작업 유형을 명시했습니다. (예: `feat: OrderPanel UI 및 API 연동`)