### PR TITLE
Feat/10 position asset status

### DIFF
--- a/backend/src/positions/positions.controller.ts
+++ b/backend/src/positions/positions.controller.ts
@@ -1,7 +1,20 @@
-import { Controller } from '@nestjs/common';
+// backend/src/positions/positions.controller.ts
+
+import { Controller, Get, UseGuards, Request } from '@nestjs/common';
 import { PositionsService } from './positions.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @Controller('positions')
 export class PositionsController {
   constructor(private readonly positionsService: PositionsService) {}
+
+  /**
+   * 현재 로그인된 사용자의 모든 포지션을 조회합니다.
+   */
+  @UseGuards(JwtAuthGuard) // 👈 이 API는 인증된 사용자만 호출 가능
+  @Get()
+  findMyPositions(@Request() req: { user: { id: string } }) {
+    const userId = req.user.id;
+    return this.positionsService.findAllByUserId(userId);
+  }
 }

--- a/backend/src/positions/positions.service.ts
+++ b/backend/src/positions/positions.service.ts
@@ -22,6 +22,18 @@ export class PositionsService {
     private readonly positionsRepository: Repository<Position>,
   ) {}
 
+  /**
+   * 특정 사용자의 모든 포지션을 조회합니다.
+   * @param userId 사용자 ID
+   * @returns 해당 사용자의 포지션 목록
+   */
+  async findAllByUserId(userId: string): Promise<Position[]> {
+    return this.positionsRepository.find({
+      where: { user: { id: userId } },
+      order: { createdAt: 'DESC' }, // 최신 포지션이 위로 오도록 정렬
+    });
+  }
+
   async createOrUpdatePosition(params: PositionParams): Promise<Position> {
     const { userId, symbol, side, quantity, entryPrice, leverage, margin } =
       params;

--- a/backend/src/wallets/wallets.controller.ts
+++ b/backend/src/wallets/wallets.controller.ts
@@ -1,7 +1,18 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, UseGuards, Request } from '@nestjs/common';
 import { WalletsService } from './wallets.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @Controller('wallets')
 export class WalletsController {
   constructor(private readonly walletsService: WalletsService) {}
+
+  /**
+   * 현재 로그인된 사용자의 지갑 정보를 조회합니다.
+   */
+  @UseGuards(JwtAuthGuard) // 👈 이 API는 인증된 사용자만 호출 가능
+  @Get()
+  findMyWallet(@Request() req: { user: { id: string } }) {
+    const userId = req.user.id;
+    return this.walletsService.findWalletByUserId(userId);
+  }
 }

--- a/backend/src/wallets/wallets.service.ts
+++ b/backend/src/wallets/wallets.service.ts
@@ -56,7 +56,7 @@ export class WalletsService {
    * @param userId 사용자 ID
    * @returns 지갑 객체
    */
-  private async findWalletByUserId(userId: string): Promise<Wallet> {
+  async findWalletByUserId(userId: string): Promise<Wallet> {
     const wallet = await this.walletsRepository.findOne({
       where: { user: { id: userId } },
     });

--- a/frontend/src/components/OrderPanel/index.tsx
+++ b/frontend/src/components/OrderPanel/index.tsx
@@ -1,20 +1,15 @@
 // frontend/src/components/OrderPanel/index.tsx
 
-import { useState } from "react";
+import React, { useState } from "react";
 import * as S from "./styles";
-import { createOrder } from '../../services/orderService'; 
+import { createOrder, type OrderPayload, type Wallet } from '../../services/orderService'; 
 
-// 나중에 API 서비스를 통해 가져올 타입들 (임시 정의)
-interface OrderPayload {
-  symbol: string;
-  type: "MARKET" | "LIMIT";
-  side: "BUY" | "SELL";
-  quantity: number;
-  leverage: number;
-  price?: number; // 지정가 주문을 위해 옵셔널
+interface OrderPanelProps {
+  wallet: Wallet | null;
+  onOrderSuccess: () => void; // 아무 인자도 받지 않고 아무것도 반환하지 않는 함수 타입
 }
 
-const OrderPanel = () => {
+const OrderPanel: React.FC<OrderPanelProps> = ({ wallet, onOrderSuccess }) => {
   // 'BUY'(롱) 또는 'SELL'(숏)을 관리하는 상태
   const [positionSide, setPositionSide] = useState<"BUY" | "SELL">("BUY");
   // 수량 입력 (BTC)
@@ -46,7 +41,7 @@ const OrderPanel = () => {
       leverage: leverage,
     };
 
-        setIsLoading(true); // 로딩 시작
+    setIsLoading(true); // 로딩 시작
     setError(null); // 이전 에러 메시지 초기화
 
     try {
@@ -57,6 +52,9 @@ const OrderPanel = () => {
       
       // 성공 시 입력 필드 초기화
       setQuantity('');
+
+      // --- 여기가 핵심! 주문 성공 후 부모에게 알립니다. ---
+      onOrderSuccess(); 
 
     } catch (err: unknown) {
       // 서비스에서 던진 에러를 잡아서 상태에 저장
@@ -120,7 +118,7 @@ const OrderPanel = () => {
         <S.InfoGroup>
           <span>주문 가능 금액:</span>
           {/* TODO: 이슈 #10에서 실제 지갑 정보와 연동됩니다. */}
-          <span>10000.00 USDT</span>
+          {wallet ? `${Number(wallet.balance).toFixed(2)} USDT` : '...'}
         </S.InfoGroup>
       </S.Form>
 

--- a/frontend/src/components/PositionStatus/index.tsx
+++ b/frontend/src/components/PositionStatus/index.tsx
@@ -1,0 +1,59 @@
+// frontend/src/components/PositionStatus/index.tsx
+
+import React from 'react';
+import * as S from './styles';
+import {type Position } from '../../services/orderService';
+
+interface PositionStatusProps {
+  positions: Position[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+const PositionStatus: React.FC<PositionStatusProps> = ({ positions, isLoading, error }) => {
+  if (isLoading) {
+    return <S.Container>로딩 중...</S.Container>;
+  }
+
+  if (error) {
+    return <S.Container>오류: {error}</S.Container>;
+  }
+
+  return (
+    <S.Container>
+      <S.Title>포지션 현황</S.Title>
+      <S.Table>
+        <thead>
+          <tr>
+            <th>종목</th>
+            <th>방향</th>
+            <th>수량</th>
+            <th>진입가</th>
+            <th>레버리지</th>
+            {/* <th>미실현손익(PNL)</th> */}
+          </tr>
+        </thead>
+        <tbody>
+          {positions?.length > 0 ? (
+            positions.map((pos) => (
+              <tr key={pos.id}>
+                <td>{pos.symbol}</td>
+                <S.PositionSideCell side={pos.side}>{pos.side}</S.PositionSideCell>
+                <td>{pos.quantity}</td>
+                <td>{Number(pos.entryPrice).toFixed(2)}</td>
+                <td>{pos.leverage}x</td>
+                {/* <td>+12.34 USDT (2.45%)</td> */}
+              </tr>
+            ))
+          ) : (
+            <tr>
+              <td colSpan={5}>보유 중인 포지션이 없습니다.</td>
+            </tr>
+          )}
+        </tbody>
+      </S.Table>
+    </S.Container>
+  );
+};
+
+export default PositionStatus;

--- a/frontend/src/components/PositionStatus/index.tsx
+++ b/frontend/src/components/PositionStatus/index.tsx
@@ -1,16 +1,43 @@
 // frontend/src/components/PositionStatus/index.tsx
 
-import React from 'react';
-import * as S from './styles';
-import {type Position } from '../../services/orderService';
+import React from "react";
+import * as S from "./styles";
+import { type Position } from "../../services/orderService";
 
 interface PositionStatusProps {
   positions: Position[];
   isLoading: boolean;
   error: string | null;
+  markPrice: number;
 }
 
-const PositionStatus: React.FC<PositionStatusProps> = ({ positions, isLoading, error }) => {
+const PositionStatus: React.FC<PositionStatusProps> = ({
+  positions,
+  isLoading,
+  error,
+  markPrice,
+}) => {
+  // PNL 계산 함수
+  const calculatePnl = (position: Position) => {
+    if (!markPrice) return { pnl: 0, pnlPercent: 0 };
+
+    const entryPrice = Number(position.entryPrice);
+    const quantity = Number(position.quantity);
+    const margin = Number(position.margin);
+
+    let pnl = 0;
+    if (position.side === "LONG") {
+      pnl = (markPrice - entryPrice) * quantity;
+    } else {
+      // SHORT
+      pnl = (entryPrice - markPrice) * quantity;
+    }
+
+    const pnlPercent = (pnl / margin) * 100;
+
+    return { pnl: pnl.toFixed(2), pnlPercent: pnlPercent.toFixed(2) };
+  };
+
   if (isLoading) {
     return <S.Container>로딩 중...</S.Container>;
   }
@@ -35,16 +62,25 @@ const PositionStatus: React.FC<PositionStatusProps> = ({ positions, isLoading, e
         </thead>
         <tbody>
           {positions?.length > 0 ? (
-            positions.map((pos) => (
-              <tr key={pos.id}>
-                <td>{pos.symbol}</td>
-                <S.PositionSideCell side={pos.side}>{pos.side}</S.PositionSideCell>
-                <td>{pos.quantity}</td>
-                <td>{Number(pos.entryPrice).toFixed(2)}</td>
-                <td>{pos.leverage}x</td>
-                {/* <td>+12.34 USDT (2.45%)</td> */}
-              </tr>
-            ))
+            positions.map((pos) => {
+              const { pnl, pnlPercent } = calculatePnl(pos);
+              return (
+                <tr key={pos.id}>
+                  <td>{pos.symbol}</td>
+                  <S.PositionSideCell side={pos.side}>
+                    {pos.side}
+                  </S.PositionSideCell>
+                  <td>{pos.quantity}</td>
+                  <td>{Number(pos.entryPrice).toFixed(2)}</td>
+                  <td>{markPrice.toFixed(2)}</td>
+                  <S.PnlCell isPositive={Number(pnl) >= 0}>
+                    {pnl} USDT ({pnlPercent}%)
+                  </S.PnlCell>
+                  <td>{pos.leverage}x</td>
+                  {/* <td>+12.34 USDT (2.45%)</td> */}
+                </tr>
+              );
+            })
           ) : (
             <tr>
               <td colSpan={5}>보유 중인 포지션이 없습니다.</td>

--- a/frontend/src/components/PositionStatus/styles.ts
+++ b/frontend/src/components/PositionStatus/styles.ts
@@ -1,0 +1,57 @@
+// frontend/src/components/PositionStatus/styles.ts
+
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  background-color: #1e222d;
+  color: #f0f0f0;
+  padding: 16px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  height: 100%;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const Title = styled.h3`
+  margin-top: 0;
+  margin-bottom: 16px;
+  font-size: 18px;
+`;
+
+export const Table = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  
+  th, td {
+    padding: 8px;
+    text-align: left;
+    border-bottom: 1px solid #2a2e39;
+  }
+
+  th {
+    font-size: 12px;
+    color: #888;
+    text-align: center;
+  }
+
+  td {
+    text-align: center;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  tbody td[colspan] {
+    text-align: center;
+    color: #888;
+    padding: 20px;
+  }
+`;
+
+export const PositionSideCell = styled.td<{ side: 'LONG' | 'SHORT' }>`
+  color: ${({ side }) => (side === 'LONG' ? '#089981' : '#f23645')};
+  font-weight: bold;
+`;

--- a/frontend/src/components/PositionStatus/styles.ts
+++ b/frontend/src/components/PositionStatus/styles.ts
@@ -55,3 +55,9 @@ export const PositionSideCell = styled.td<{ side: 'LONG' | 'SHORT' }>`
   color: ${({ side }) => (side === 'LONG' ? '#089981' : '#f23645')};
   font-weight: bold;
 `;
+
+// PNL 셀 스타일 추가
+export const PnlCell = styled.td<{ isPositive: boolean }>`
+  color: ${({ isPositive }) => (isPositive ? '#089981' : '#f23645')};
+  font-weight: 500;
+`;

--- a/frontend/src/pages/TradingPage.tsx
+++ b/frontend/src/pages/TradingPage.tsx
@@ -1,16 +1,25 @@
 // frontend/src/pages/TradingPage.tsx
 
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 import { TradingChart } from "../components/TradingChart";
 import OrderPanel from "../components/OrderPanel";
+import PositionStatus from "../components/PositionStatus";
+import {
+  getMyPositions,
+  getMyWallet,
+  type Position,
+  type Wallet,
+} from "../services/orderService";
 
 const TradingPageContainer = styled.div`
   display: grid;
   grid-template-areas:
     "chart order-panel"
-    "chart order-book";
+    "chart order-book"
+    "positions positions";
   grid-template-columns: 3fr 1fr; /* 차트가 3, 오른쪽 패널이 1의 비율 */
-  grid-template-rows: 1fr 1fr;
+  grid-template-rows: 1fr 1fr auto; /* 3번째 행 크기 자동 조절 */
   height: 95vh;
   width: 100%;
   background-color: #131722;
@@ -35,16 +44,78 @@ const OrderBookContainer = styled.div`
   background-color: #1e222d;
 `;
 
+const PositionStatusContainer = styled.div`
+  grid-area: positions;
+  background-color: #1e222d;
+  min-height: 150px; /* 최소 높이 지정 */
+`;
+
 export const TradingPage = () => {
+  const [positions, setPositions] = useState<Position[]>([]);
+  const [wallet, setWallet] = useState<Wallet | null>(null); // wallet 상태 추가
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchPositions = async () => {
+    try {
+      setIsLoading(true);
+      const data = await getMyPositions();
+      setPositions(data);
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("데이터를 불러오는 중 알 수 없는 오류가 발생했습니다.");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const fetchWallet = async () => {
+    try {
+      const data = await getMyWallet();
+      setWallet(data);
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message);
+      } else {
+        setError("지갑 정보를 불러오는 중 알 수 없는 오류가 발생했습니다.");
+      }
+    }
+  };
+
+  // 주문 성공 시, 포지션과 지갑 정보를 모두 다시 불러옵니다.
+  const handleOrderSuccess = async () => {
+    await Promise.all([fetchPositions(), fetchWallet()]);
+  };
+
+  // 최초 로딩 시, 포지션과 지갑 정보를 병렬로 가져옵니다.
+  useEffect(() => {
+    const initialFetch = async () => {
+      setIsLoading(true);
+      await Promise.all([fetchPositions(), fetchWallet()]);
+      setIsLoading(false);
+    };
+    initialFetch();
+  }, []);
+
   return (
     <TradingPageContainer>
       <ChartContainer>
         <TradingChart />
       </ChartContainer>
       <OrderPanelContainer>
-        <OrderPanel />
+        <OrderPanel wallet={wallet} onOrderSuccess={handleOrderSuccess} />
       </OrderPanelContainer>
       <OrderBookContainer>호가창</OrderBookContainer>
+      <PositionStatusContainer>
+        <PositionStatus
+          positions={positions}
+          isLoading={isLoading}
+          error={error}
+        />
+      </PositionStatusContainer>
     </TradingPageContainer>
   );
 };

--- a/frontend/src/pages/TradingPage.tsx
+++ b/frontend/src/pages/TradingPage.tsx
@@ -11,6 +11,7 @@ import {
   type Position,
   type Wallet,
 } from "../services/orderService";
+import { socket } from '../services/socket';
 
 const TradingPageContainer = styled.div`
   display: grid;
@@ -50,9 +51,16 @@ const PositionStatusContainer = styled.div`
   min-height: 150px; /* 최소 높이 지정 */
 `;
 
+// Binance WebSocket 'trade' 이벤트의 데이터 타입
+interface TradeData {
+  p: string; // Price
+  // ... 다른 속성들
+}
+
 export const TradingPage = () => {
   const [positions, setPositions] = useState<Position[]>([]);
   const [wallet, setWallet] = useState<Wallet | null>(null); // wallet 상태 추가
+  const [markPrice, setMarkPrice] = useState<number>(0); // 실시간 현재가(Mark Price) 상태
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -97,7 +105,21 @@ export const TradingPage = () => {
       await Promise.all([fetchPositions(), fetchWallet()]);
       setIsLoading(false);
     };
+
     initialFetch();
+
+    // WebSocket 연결 및 이벤트 핸들러 등록
+    socket.connect();
+    const handleTrade = (trade: TradeData) => {
+      setMarkPrice(parseFloat(trade.p));
+    };
+    socket.on('trade', handleTrade); // 'trade' 이벤트 구독
+
+    // 컴포넌트 언마운트 시 클린업
+    return () => {
+      socket.off('trade', handleTrade);
+      socket.disconnect();
+    };
   }, []);
 
   return (
@@ -114,6 +136,7 @@ export const TradingPage = () => {
           positions={positions}
           isLoading={isLoading}
           error={error}
+          markPrice={markPrice} 
         />
       </PositionStatusContainer>
     </TradingPageContainer>

--- a/frontend/src/services/orderService.ts
+++ b/frontend/src/services/orderService.ts
@@ -49,3 +49,55 @@ export const createOrder = async (
     throw new Error("알 수 없는 오류가 발생했습니다.");
   }
 };
+
+
+
+// 백엔드의 Position 엔티티 타입과 맞춥니다.
+export interface Position {
+  id: string;
+  symbol: string;
+  side: 'LONG' | 'SHORT';
+  quantity: number;
+  entryPrice: number;
+  liquidationPrice: number;
+  leverage: number;
+  margin: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// 백엔드의 Wallet 엔티티 타입과 맞춥니다.
+export interface Wallet {
+  id: string;
+  balance: number;
+}
+
+/**
+ * 현재 로그인된 사용자의 모든 포지션을 가져옵니다.
+ */
+export const getMyPositions = async (): Promise<Position[]> => {
+  try {
+    const response = await apiClient.get<Position[]>('/positions');
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      throw new Error(error.response.data.message || '포지션 정보를 가져오는데 실패했습니다.');
+    }
+    throw new Error('알 수 없는 오류가 발생했습니다.');
+  }
+};
+
+/**
+ * 현재 로그인된 사용자의 지갑 정보를 가져옵니다.
+ */
+export const getMyWallet = async (): Promise<Wallet> => {
+  try {
+    const response = await apiClient.get<Wallet>('/wallets');
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      throw new Error(error.response.data.message || '지갑 정보를 가져오는데 실패했습니다.');
+    }
+    throw new Error('알 수 없는 오류가 발생했습니다.');
+  }
+};


### PR DESCRIPTION
## 📝 작업 내용 (Description)

사용자의 포지션 및 자산 현황을 조회하고, 실시간 미실현 손익(PNL)을 화면에 표시하는 기능을 구현.

<br>

## ✅ 관련 이슈 (Related Issues)

- Closes #10

<br>

## ✨ 변경점 (Changes)

- **백엔드:**
    - `GET /positions`: 현재 사용자의 모든 포지션을 조회하는 API 구현.
    - `GET /wallets`: 현재 사용자의 지갑 정보를 조회하는 API 구현.
- **프론트엔드:**
    - **API 서비스:** `getMyPositions`, `getMyWallet` 함수 추가.
    - **`PositionStatus` 컴포넌트:**
        - 포지션 목록을 테이블 형태로 표시.
        - WebSocket(`trade` 이벤트)으로 수신한 실시간 가격을 기반으로 미실현 손익(PNL)을 계산하고 표시.
    - **`OrderPanel` 컴포넌트:**
        - 사용자의 지갑 잔고(주문 가능 금액) 표시 기능 추가.
    - **`TradingPage` (상태 관리):**
        - `positions`, `wallet`, `markPrice` 상태를 중앙에서 관리.
        - '상태 끌어올리기' 패턴을 적용하여, 신규 주문 시 포지션과 지갑 정보가 자동으로 갱신되도록 리팩토링 완료.

<br>

---

### Self-Checklist

- [x] `develop` 브랜치로 PR을 요청합니다.
- [x] PR 제목에 작업 유형을 명시했습니다. (예: `feat: 실시간 포지션 및 자산 현황 표시`)