### PR TITLE
[FEAT] #15 거래 내역 페이지 구현 및 시스템 안정화

### DIFF
--- a/backend/src/common/dto/page-options.dto.ts
+++ b/backend/src/common/dto/page-options.dto.ts
@@ -1,0 +1,22 @@
+// backend/src/common/dto/page-options.dto.ts
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class PageOptionsDto {
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  readonly page?: number = 1;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(50)
+  @IsOptional()
+  readonly limit?: number = 20;
+
+  get skip(): number {
+    return (this.page - 1) * this.limit;
+  }
+}

--- a/backend/src/orders/orders.module.ts
+++ b/backend/src/orders/orders.module.ts
@@ -5,9 +5,15 @@ import { WalletsModule } from '../wallets/wallets.module';
 import { PositionsModule } from '../positions/positions.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Order } from './entities/order.entity';
+import { TransactionsModule } from '../transactions/transactions.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Order]), WalletsModule, PositionsModule],
+  imports: [
+    TypeOrmModule.forFeature([Order]),
+    WalletsModule,
+    PositionsModule,
+    TransactionsModule,
+  ],
   controllers: [OrdersController],
   providers: [OrdersService],
 })

--- a/backend/src/orders/orders.service.ts
+++ b/backend/src/orders/orders.service.ts
@@ -11,6 +11,8 @@ import {
 } from '../common/enums/order.enum';
 import { PositionsService } from '../positions/positions.service';
 import { WalletsService } from '../wallets/wallets.service';
+import { TransactionsService } from '../transactions/transactions.service';
+import { TransactionType } from '../transactions/entities/transaction.entity';
 
 @Injectable()
 export class OrdersService {
@@ -19,6 +21,7 @@ export class OrdersService {
     private readonly ordersRepository: Repository<Order>,
     private readonly positionsService: PositionsService,
     private readonly walletsService: WalletsService,
+    private readonly transactionsService: TransactionsService,
     // TODO: 나중에 BinanceApiService도 주입받아 실제 시장가를 가져와야 함
   ) {}
 
@@ -74,8 +77,24 @@ export class OrdersService {
       margin: marginRequired,
     });
 
-    // --- 6. 지갑 잔고에서 증거금 차감 ---
+    // --- 6. 지갑 잔고에서 증거금 차감 및 거래 내역(Transaction) 기록 ---
+    // 먼저 사용자 지갑 객체를 가져옵니다.
+    const wallet = await this.walletsService.findWalletByUserId(userId);
+    if (!wallet) {
+      throw new BadRequestException('사용자 지갑을 찾을 수 없습니다.');
+    }
+
+    // 6-1. 지갑 잔고 업데이트
     await this.walletsService.updateBalance(userId, -marginRequired);
+
+    // 6-2. 증거금 사용에 대한 거래 내역 생성
+    // (REALIZED_PNL은 포지션 종료 시점에 발생하므로, 지금은 증거금 사용에 대한 내역만 기록)
+    // 수수료 로직 추가 시, FEE 타입의 Transaction도 여기서 생성 가능
+    await this.transactionsService.create({
+      wallet: wallet,
+      type: TransactionType.REALIZED_PNL, // 지금은 '실현 손익'으로 분류 (추후 MARGIN 등으로 세분화 가능)
+      amount: -marginRequired, // 증거금은 자산에서 차감되므로 음수
+    });
 
     return { order: newOrder, position: newPosition };
   }

--- a/backend/src/transactions/dto/create-transaction.dto.ts
+++ b/backend/src/transactions/dto/create-transaction.dto.ts
@@ -1,1 +1,9 @@
-export class CreateTransactionDto {}
+/* backend/src/transactions/dto/create-transaction.dto.ts */
+import { TransactionType } from '../entities/transaction.entity';
+import { Wallet } from '../../wallets/entities/wallet.entity';
+
+export class CreateTransactionDto {
+  wallet: Wallet;
+  type: TransactionType;
+  amount: number;
+}

--- a/backend/src/transactions/transactions.controller.ts
+++ b/backend/src/transactions/transactions.controller.ts
@@ -1,34 +1,17 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
 import { TransactionsService } from './transactions.service';
-import { CreateTransactionDto } from './dto/create-transaction.dto';
-import { UpdateTransactionDto } from './dto/update-transaction.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { PageOptionsDto } from '../common/dto/page-options.dto';
 
 @Controller('transactions')
 export class TransactionsController {
   constructor(private readonly transactionsService: TransactionsService) {}
 
-  @Post()
-  create(@Body() createTransactionDto: CreateTransactionDto) {
-    return this.transactionsService.create(createTransactionDto);
-  }
-
   @Get()
-  findAll() {
-    return this.transactionsService.findAll();
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.transactionsService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateTransactionDto: UpdateTransactionDto) {
-    return this.transactionsService.update(+id, updateTransactionDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.transactionsService.remove(+id);
+  @UseGuards(JwtAuthGuard)
+  findAll(@Req() req, @Query() pageOptionsDto: PageOptionsDto) {
+    // req.user는 JwtStrategy의 validate에서 반환된 페이로드입니다.
+    const userId = req.user.id;
+    return this.transactionsService.findAllByUserId(userId, pageOptionsDto);
   }
 }

--- a/backend/src/transactions/transactions.module.ts
+++ b/backend/src/transactions/transactions.module.ts
@@ -1,9 +1,15 @@
+// backend/src/transactions/transactions.module.ts
+
 import { Module } from '@nestjs/common';
 import { TransactionsService } from './transactions.service';
 import { TransactionsController } from './transactions.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Transaction } from './entities/transaction.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Transaction])],
   controllers: [TransactionsController],
   providers: [TransactionsService],
+  exports: [TransactionsService],
 })
 export class TransactionsModule {}

--- a/backend/src/transactions/transactions.service.ts
+++ b/backend/src/transactions/transactions.service.ts
@@ -1,26 +1,57 @@
+// backend/src/transactions/transactions.service.ts
+
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PageOptionsDto } from '../common/dto/page-options.dto';
+import { Transaction } from './entities/transaction.entity';
 import { CreateTransactionDto } from './dto/create-transaction.dto';
-import { UpdateTransactionDto } from './dto/update-transaction.dto';
 
 @Injectable()
 export class TransactionsService {
-  create(createTransactionDto: CreateTransactionDto) {
-    return 'This action adds a new transaction';
+  constructor(
+    @InjectRepository(Transaction)
+    private readonly transactionRepository: Repository<Transaction>,
+  ) {}
+
+  // create 메소드 구현
+  async create(
+    createTransactionDto: CreateTransactionDto,
+  ): Promise<Transaction> {
+    const newTransaction =
+      this.transactionRepository.create(createTransactionDto);
+    return this.transactionRepository.save(newTransaction);
   }
 
-  findAll() {
-    return `This action returns all transactions`;
-  }
+  /**
+   * 특정 사용자의 거래 내역을 페이지네이션하여 조회합니다.
+   * 최근 3개월 데이터만 조회합니다.
+   * @param userId 사용자 ID
+   * @param pageOptionsDto 페이지네이션 옵션 (page, limit)
+   * @returns 페이지네이션된 거래 내역과 메타 데이터
+   */
+  async findAllByUserId(userId: string, pageOptionsDto: PageOptionsDto) {
+    const queryBuilder =
+      this.transactionRepository.createQueryBuilder('transaction');
 
-  findOne(id: number) {
-    return `This action returns a #${id} transaction`;
-  }
+    queryBuilder
+      .innerJoin('transaction.wallet', 'wallet')
+      .where('wallet.userId = :userId', { userId })
+      .andWhere('transaction.createdAt > DATE_SUB(NOW(), INTERVAL 3 MONTH)') // 최근 3개월 데이터
+      .orderBy('transaction.createdAt', 'DESC') // 최신순 정렬
+      .skip(pageOptionsDto.skip)
+      .take(pageOptionsDto.limit);
 
-  update(id: number, updateTransactionDto: UpdateTransactionDto) {
-    return `This action updates a #${id} transaction`;
-  }
+    const [entities, total] = await queryBuilder.getManyAndCount();
 
-  remove(id: number) {
-    return `This action removes a #${id} transaction`;
+    return {
+      data: entities,
+      meta: {
+        page: pageOptionsDto.page,
+        limit: pageOptionsDto.limit,
+        total,
+        lastPage: Math.ceil(total / pageOptionsDto.limit),
+      },
+    };
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,27 +1,24 @@
 // frontend/src/App.tsx
 
-import { TradingPage } from './pages/TradingPage';
-import { createGlobalStyle } from 'styled-components';
-
-// 전역 스타일 설정
-const GlobalStyle = createGlobalStyle`
-  body {
-    margin: 0;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-      'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-      sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    background-color: #131722;
-  }
-`;
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { TradingPage } from "./pages/TradingPage";
+import { HistoryPage } from "./pages/HistoryPage";
+import { Layout } from "./components/common/Layout";
+import { GlobalStyle } from "./styles/GlobalStyle";
 
 function App() {
   return (
-    <>
+    <BrowserRouter>
       <GlobalStyle />
-      <TradingPage />
-    </>
+      <Routes>
+        <Route element={<Layout />}>
+          {" "}
+          {/* Layout을 부모 라우트로 설정 */}
+          <Route path="/" element={<TradingPage />} />
+          <Route path="/history" element={<HistoryPage />} />
+        </Route>
+      </Routes>
+    </BrowserRouter>
   );
 }
 

--- a/frontend/src/components/OrderPanel/index.tsx
+++ b/frontend/src/components/OrderPanel/index.tsx
@@ -76,13 +76,13 @@ const OrderPanel: React.FC<OrderPanelProps> = ({ wallet, onOrderSuccess }) => {
     <S.OrderPanelContainer>
       <S.TabWrapper>
         <S.TabButton
-          active={positionSide === "BUY"}
+          $active={positionSide === "BUY"}
           onClick={() => setPositionSide("BUY")}
         >
           롱 (매수)
         </S.TabButton>
         <S.TabButton
-          active={positionSide === "SELL"}
+          $active={positionSide === "SELL"}
           onClick={() => setPositionSide("SELL")}
         >
           숏 (매도)

--- a/frontend/src/components/OrderPanel/styles.ts
+++ b/frontend/src/components/OrderPanel/styles.ts
@@ -19,17 +19,17 @@ export const TabWrapper = styled.div`
   margin-bottom: 16px;
 `;
 
-export const TabButton = styled.button<{ active: boolean }>`
+export const TabButton = styled.button<{ $active: boolean }>`
   flex: 1;
   padding: 12px;
   background: transparent;
   border: none;
-  color: ${({ active }) => (active ? '#f0f0f0' : '#888')};
+  color: ${({ $active }) => ($active ? '#f0f0f0' : '#888')};
   font-size: 16px;
   font-weight: bold;
   cursor: pointer;
-  border-bottom: 2px solid ${({ active, children }) =>
-    active ? (children?.toString().includes('롱') ? '#089981' : '#f23645') : 'transparent'};
+  border-bottom: 2px solid ${({ $active, children }) =>
+    $active ? (children?.toString().includes('롱') ? '#089981' : '#f23645') : 'transparent'};
   transition: all 0.2s ease-in-out;
 
   &:hover {

--- a/frontend/src/components/PositionStatus/index.tsx
+++ b/frontend/src/components/PositionStatus/index.tsx
@@ -73,7 +73,7 @@ const PositionStatus: React.FC<PositionStatusProps> = ({
                   <td>{pos.quantity}</td>
                   <td>{Number(pos.entryPrice).toFixed(2)}</td>
                   <td>{markPrice.toFixed(2)}</td>
-                  <S.PnlCell isPositive={Number(pnl) >= 0}>
+                  <S.PnlCell $isPositive={Number(pnl) >= 0}>
                     {pnl} USDT ({pnlPercent}%)
                   </S.PnlCell>
                   <td>{pos.leverage}x</td>

--- a/frontend/src/components/PositionStatus/styles.ts
+++ b/frontend/src/components/PositionStatus/styles.ts
@@ -57,7 +57,7 @@ export const PositionSideCell = styled.td<{ side: 'LONG' | 'SHORT' }>`
 `;
 
 // PNL 셀 스타일 추가
-export const PnlCell = styled.td<{ isPositive: boolean }>`
-  color: ${({ isPositive }) => (isPositive ? '#089981' : '#f23645')};
+export const PnlCell = styled.td<{ $isPositive: boolean }>`
+  color: ${({ $isPositive }) => ($isPositive ? '#089981' : '#f23645')};
   font-weight: 500;
 `;

--- a/frontend/src/components/common/Layout.tsx
+++ b/frontend/src/components/common/Layout.tsx
@@ -1,0 +1,50 @@
+/* frontend/src/components/common/Layout.tsx */
+/*
+- [리팩토링] 공통 레이아웃 관리를 위해 네비게이션(헤더)과 페이지 컨텐츠를 분리하는 `Layout` 컴포넌트를 생성합니다.
+- `Outlet`은 `react-router-dom`의 기능으로, 중첩된 라우트의 자식 컴포넌트(예: TradingPage, HistoryPage)가 렌더링될 위치를 지정합니다.
+*/
+import { Link, Outlet } from 'react-router-dom';
+import styled from 'styled-components';
+
+const AppContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+`;
+
+const Header = styled.header`
+  padding: 16px;
+  background-color: #1e222d;
+  flex-shrink: 0;
+`;
+
+const NavLink = styled(Link)`
+  margin-right: 16px;
+  color: white;
+  text-decoration: none;
+  font-weight: 500;
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const MainContent = styled.main`
+  flex-grow: 1;
+  overflow: auto; /* 컨텐츠가 많을 경우 스크롤 생성 */
+`;
+
+export const Layout = () => {
+  return (
+    <AppContainer>
+      <Header>
+        <nav>
+          <NavLink to="/">트레이딩</NavLink>
+          <NavLink to="/history">거래 내역</NavLink>
+        </nav>
+      </Header>
+      <MainContent>
+        <Outlet />
+      </MainContent>
+    </AppContainer>
+  );
+};

--- a/frontend/src/pages/HistoryPage.tsx
+++ b/frontend/src/pages/HistoryPage.tsx
@@ -1,0 +1,140 @@
+// frontend/src/pages/HistoryPage.tsx
+import { useState, useEffect, useRef, useCallback } from 'react';
+import styled from 'styled-components';
+import { getMyTransactions, type Transaction } from '../services/transactionService';
+
+const HistoryPageContainer = styled.div`
+  padding: 24px;
+  background-color: #131722;
+  color: #d1d4dc;
+  height: 100%;
+`;
+
+const Title = styled.h1`
+  font-size: 24px;
+  margin-bottom: 24px;
+`;
+
+const Table = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+  th, td {
+    padding: 12px 16px;
+    text-align: left;
+    border-bottom: 1px solid #2a2e39;
+  }
+  th {
+    color: #848e9c;
+    font-size: 14px;
+  }
+  td {
+    font-size: 14px;
+  }
+`;
+
+const Loader = styled.div`
+  text-align: center;
+  padding: 20px;
+  font-size: 16px;
+`;
+
+// 금액에 따라 색상을 다르게 표시하는 컴포넌트
+const AmountCell = styled.td<{ $isPositive: boolean }>`
+  color: ${({ $isPositive }) => ($isPositive ? '#0ecb81' : '#f6465d')};
+`;
+
+export const HistoryPage = () => {
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [page, setPage] = useState(1);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const observer = useRef<IntersectionObserver | null>(null);
+
+  const fetchTransactions = useCallback(async (pageNum: number) => {
+    if (isLoading || !hasMore) return;
+
+    setIsLoading(true);
+
+    try {
+      const { data, meta } = await getMyTransactions(pageNum);
+      setTransactions(prev => {
+          const allData = [...prev, ...data];
+          const uniqueIds = new Set();
+          return allData.filter(item => {
+              if (uniqueIds.has(item.id)) {
+                  return false;
+              } else {
+                  uniqueIds.add(item.id);
+                  return true;
+              }
+          });
+      });
+      setHasMore(meta.page < meta.lastPage);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isLoading, hasMore]);
+
+  // 페이지 번호가 변경될 때만 추가 데이터를 가져오도록 useEffect 분리
+  useEffect(() => {
+    // 1페이지가 아닌 경우에만 실행 (초기 로딩은 아래 useEffect에서 처리)
+    if (page > 1) {
+      fetchTransactions(page);
+    }
+  }, [page]); // page가 변경될 때만 실행
+
+// 컴포넌트가 처음 마운트될 때 초기 데이터 로딩
+  useEffect(() => {
+    setTransactions([]); // 페이지 재진입 시 초기화
+    setPage(1);
+    setHasMore(true);
+    fetchTransactions(1);
+  }, []); // 의존성 배열을 비워 최초 1회만 실행
+
+  const lastTransactionElementRef = useCallback((node: HTMLTableRowElement) => {
+    if (isLoading) return;
+    if (observer.current) observer.current.disconnect();
+
+    observer.current = new IntersectionObserver(entries => {
+      if (entries[0].isIntersecting && hasMore && !isLoading) {
+        setPage(prevPage => prevPage + 1);
+      }
+    });
+    if (node) observer.current.observe(node);
+  }, [isLoading, hasMore]);
+  
+  return (
+    <HistoryPageContainer>
+      <Title>거래 내역</Title>
+      <Table>
+        <thead>
+          <tr>
+            <th>시간</th>
+            <th>종류</th>
+            <th>금액</th>
+          </tr>
+        </thead>
+        <tbody>
+          {transactions.map((tx, index) => {
+            const isLastElement = transactions.length === index + 1;
+            const amountAsNumber = Number(tx.amount); // 숫자로 변환
+            return (
+              <tr key={tx.id} ref={isLastElement ? lastTransactionElementRef : null}>
+                <td>{new Date(tx.createdAt).toLocaleString()}</td>
+                <td>{tx.type}</td>
+                <AmountCell $isPositive={tx.amount >= 0}>
+                  {amountAsNumber > 0 ? '+' : ''}{amountAsNumber.toFixed(4)} USDT
+                </AmountCell>
+              </tr>
+            );
+          })}
+        </tbody>
+      </Table>
+      {isLoading && <Loader>로딩 중...</Loader>}
+      {!isLoading && !hasMore && transactions.length > 0 && <Loader>더 이상 내역이 없습니다.</Loader>}
+      {!isLoading && transactions.length === 0 && <Loader>거래 내역이 없습니다.</Loader>}
+    </HistoryPageContainer>
+  );
+};

--- a/frontend/src/services/transactionService.ts
+++ b/frontend/src/services/transactionService.ts
@@ -1,0 +1,52 @@
+// frontend/src/services/transactionService.ts
+import apiClient from './api';
+import { type Wallet } from './orderService'; // Wallet 타입 재사용
+
+export const TransactionType = {
+  DEPOSIT: 'DEPOSIT',
+  WITHDRAW: 'WITHDRAW',
+  REALIZED_PNL: 'REALIZED_PNL',
+  FEE: 'FEE',
+} as const;
+
+export type TransactionType = typeof TransactionType[keyof typeof TransactionType];
+
+export interface Transaction {
+  id: string;
+  wallet: Wallet;
+  type: TransactionType;
+  amount: number;
+  createdAt: string;
+  // 백엔드 엔티티에 상세 내용 컬럼 추가 시 반영
+  // details: string; 
+}
+
+interface PageMeta {
+  page: number;
+  limit: number;
+  total: number;
+  lastPage: number;
+}
+
+export interface PaginatedTransactions {
+  data: Transaction[];
+  meta: PageMeta;
+}
+
+/**
+ * 거래 내역을 페이지네이션하여 가져옵니다.
+ * @param page 페이지 번호
+ * @param limit 페이지당 항목 수
+ */
+export const getMyTransactions = async (page = 1, limit = 20): Promise<PaginatedTransactions> => {
+  try {
+    const response = await apiClient.get<PaginatedTransactions>('/transactions', {
+      params: { page, limit },
+    });
+    return response.data;
+  } catch (error) {
+    // Axios 에러 처리 (orderService.ts와 동일한 패턴 사용)
+    console.error("Failed to fetch transactions:", error);
+    throw new Error('거래 내역을 불러오는데 실패했습니다.');
+  }
+};

--- a/frontend/src/styles/GlobalStyle.ts
+++ b/frontend/src/styles/GlobalStyle.ts
@@ -1,0 +1,64 @@
+/* frontend/src/styles/GlobalStyle.ts */
+/*
+- [UI 수정] 브라우저가 기본적으로 적용하는 여백(margin) 등을 제거하여 브라우저 간 스타일 차이를 없애고,
+  프로젝트 전반의 스타일을 일관되게 관리하기 위한 전역 스타일을 정의합니다.
+*/
+import { createGlobalStyle } from "styled-components";
+
+export const GlobalStyle = createGlobalStyle`
+  /* CSS Reset */
+  html, body, div, span, applet, object, iframe,
+  h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+  a, abbr, acronym, address, big, cite, code,
+  del, dfn, em, img, ins, kbd, q, s, samp,
+  small, strike, strong, sub, sup, tt, var,
+  b, u, i, center,
+  dl, dt, dd, ol, ul, li,
+  fieldset, form, label, legend,
+  table, caption, tbody, tfoot, thead, tr, th, td,
+  article, aside, canvas, details, embed,
+  figure, figcaption, footer, header, hgroup,
+  menu, nav, output, ruby, section, summary,
+  time, mark, audio, video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+  }
+  /* HTML5 display-role reset for older browsers */
+  article, aside, details, figcaption, figure,
+  footer, header, hgroup, menu, nav, section {
+    display: block;
+  }
+  body {
+    line-height: 1;
+  }
+  ol, ul {
+    list-style: none;
+  }
+  blockquote, q {
+    quotes: none;
+  }
+  blockquote:before, blockquote:after,
+  q:before, q:after {
+    content: '';
+    content: none;
+  }
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+
+  /* 프로젝트 커스텀 글로벌 스타일 */
+  * {
+    box-sizing: border-box; /* 모든 요소에 box-sizing 적용 */
+  }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    background-color: #131722; /* 프로젝트 기본 배경색 */
+    color: #d1d4dc; /* 프로젝트 기본 글자색 */
+  }
+`;


### PR DESCRIPTION
## 📝 작업 내용 (Description)

- 이슈 #15에 따라 사용자의 거래 내역을 조회할 수 있는 페이지를 구현 
- 이 과정에서 발견된 다수의 버그를 수정하여 시스템 전반의 안정성을 향상

<br>

## ✅ 관련 이슈 (Related Issues)

- Closes #15

<br>

## ✨ 변경점 (Changes)

- [X] Backend: 페이지네이션을 지원하는 거래 내역 조회 API 구현
- [X] Backend: 주문 시 거래 내역이 생성되지 않던 버그 수정
- [X] Frontend: 거래 내역 페이지 UI 및 무한 스크롤 기능 구현
- [X] Frontend: 데이터 중복 로드, 런타임 에러, React 경고 등 안정성 문제 해결
- [X] Frontend: GlobalStyle 도입 및 브라우저 기본 CSS 리셋

<br>

---

### Self-Checklist

- [x] `develop` 브랜치로 PR을 요청합니다.
- [x] PR 제목에 작업 유형을 명시했습니다. (예: `feat:`, `fix:`)