### PR TITLE
feat: #18 주문 시 실제 시장가 연동

### DIFF
--- a/backend/src/binance/binance.service.ts
+++ b/backend/src/binance/binance.service.ts
@@ -1,14 +1,20 @@
 // backend/src/binance/binance.service.ts
 
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import {
+  Injectable,
+  OnModuleInit,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, map } from 'rxjs';
 import * as WebSocket from 'ws';
 import { EventsGateway } from 'src/events/events.gateway';
 
 @Injectable()
 export class BinanceApiService implements OnModuleInit {
+  private readonly logger = new Logger(BinanceApiService.name);
   private readonly apiKey: string;
   private readonly secretKey: string;
   // 바이낸스 선물 API 기본 URL
@@ -108,5 +114,32 @@ export class BinanceApiService implements OnModuleInit {
     ws.on('error', (error) => {
       console.error('Binance WebSocket Error:', error);
     });
+  }
+
+  /**
+   * [feat] 특정 심볼의 현재 시장가를 조회합니다.
+   * @param symbol 조회할 심볼 (예: 'BTCUSDT')
+   * @returns 현재 시장가 (숫자)
+   */
+  async getMarketPrice(symbol: string): Promise<number> {
+    const url = `${this.baseURL}/fapi/v1/ticker/price`;
+    try {
+      const response$ = this.httpService
+        .get(url, { params: { symbol } })
+        .pipe(map((resp) => resp.data));
+
+      const data = await firstValueFrom(response$);
+      console.log(`Current market price for ${symbol}:`, data.price);
+      // 바이낸스 API 응답: { "symbol": "BTCUSDT", "price": "50000.00", ... }
+      return parseFloat(data.price);
+    } catch (error) {
+      this.logger.error(
+        `Failed to fetch market price for ${symbol}:`,
+        error.response?.data || error.message,
+      );
+      throw new InternalServerErrorException(
+        `Failed to fetch market price for ${symbol}`,
+      );
+    }
   }
 }

--- a/backend/src/orders/orders.module.ts
+++ b/backend/src/orders/orders.module.ts
@@ -6,6 +6,7 @@ import { PositionsModule } from '../positions/positions.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Order } from './entities/order.entity';
 import { TransactionsModule } from '../transactions/transactions.module';
+import { BinanceModule } from '../binance/binance.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { TransactionsModule } from '../transactions/transactions.module';
     WalletsModule,
     PositionsModule,
     TransactionsModule,
+    BinanceModule,
   ],
   controllers: [OrdersController],
   providers: [OrdersService],

--- a/backend/src/orders/orders.service.ts
+++ b/backend/src/orders/orders.service.ts
@@ -13,6 +13,7 @@ import { PositionsService } from '../positions/positions.service';
 import { WalletsService } from '../wallets/wallets.service';
 import { TransactionsService } from '../transactions/transactions.service';
 import { TransactionType } from '../transactions/entities/transaction.entity';
+import { BinanceApiService } from '../binance/binance.service';
 
 @Injectable()
 export class OrdersService {
@@ -22,7 +23,7 @@ export class OrdersService {
     private readonly positionsService: PositionsService,
     private readonly walletsService: WalletsService,
     private readonly transactionsService: TransactionsService,
-    // TODO: 나중에 BinanceApiService도 주입받아 실제 시장가를 가져와야 함
+    private readonly binanceApiService: BinanceApiService,
   ) {}
 
   async createOrder(userId: string, createOrderDto: CreateOrderDto) {
@@ -31,17 +32,17 @@ export class OrdersService {
       throw new BadRequestException('지정가 주문은 현재 지원되지 않습니다.');
     }
 
+    const { symbol, side, quantity, leverage } = createOrderDto; // 종목, 방향, 수량, 레버리지
+
     // --- 1. 모의 시장가 가져오기 ---
     // TODO: 실제로는 BinanceApiService를 통해 현재 시장가를 가져와야 함
-    const mockMarketPrice = 50000.0; // 임시 모의 시장가
-
-    const { symbol, side, quantity, leverage } = createOrderDto; // 종목, 방향, 수량, 레버리지
+    const marketPrice = await this.binanceApiService.getMarketPrice(symbol);
 
     // --- 2. 필요한 증거금(margin) 계산 ---
     // 총 거래대금 = (체결 가격) * (주문 수량), 즉 50000 * quantity
     // 필요 증거금 = (총 거래대금) / (레버리지)
     // 예: 10배 레버리지로 0.1 BTC (5,000달러어치)를 주문하면, 필요한 내 돈은 500달러
-    const marginRequired = (mockMarketPrice * quantity) / leverage;
+    const marginRequired = (marketPrice * quantity) / leverage;
 
     // --- 3. 사용자 지갑 잔고 확인 ---
     const hasSufficientBalance = await this.walletsService.checkBalance(
@@ -58,7 +59,7 @@ export class OrdersService {
       symbol,
       type: OrderType.MARKET,
       side,
-      price: mockMarketPrice, // 체결된 시장가로 기록
+      price: marketPrice, // 체결된 시장가로 기록
       quantity,
       status: OrderStatus.FILLED, // 시장가는 즉시 체결
     });
@@ -72,7 +73,7 @@ export class OrdersService {
       symbol,
       side: positionSide,
       quantity,
-      entryPrice: mockMarketPrice,
+      entryPrice: marketPrice,
       leverage,
       margin: marginRequired,
     });


### PR DESCRIPTION
## 📝 작업 내용 (Description)

> 주문 체결 시 하드코딩된 모의 시장가 대신, 바이낸스 API를 통해 조회한 실제 시장가를 사용하도록 시스템을 개선

<br>

## ✅ 관련 이슈 (Related Issues)

- Closes #18 

<br>

## ✨ 변경점 (Changes)

- [X] `BinanceApiService`에 실시간 시장가를 조회하는 `getMarketPrice` 메소드를 추가했습니다.
- [X] `OrdersService`에서 `BinanceApiService`를 호출하여 실제 시장가를 가져오도록 수정했습니다.
- [X] 주문 생성 및 포지션 진입 시 모든 가격 관련 로직이 실제 시장가를 기반으로 동작하도록 변경했습니다.

<br>

---

### Self-Checklist

- [x] `develop` 브랜치로 PR을 요청합니다.
- [x] PR 제목에 작업 유형을 명시했습니다. (예: `feat:`, `fix:`)