### PR TITLE
feat: #24 거래 수수료 부과 및 기록 로직 구현

### DIFF
--- a/backend/src/orders/orders.service.ts
+++ b/backend/src/orders/orders.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { CreateOrderDto } from './dto/create-order.dto';
@@ -24,6 +25,7 @@ export class OrdersService {
     private readonly walletsService: WalletsService,
     private readonly transactionsService: TransactionsService,
     private readonly binanceApiService: BinanceApiService,
+    private readonly configService: ConfigService,
   ) {}
 
   async createOrder(userId: string, createOrderDto: CreateOrderDto) {
@@ -78,8 +80,8 @@ export class OrdersService {
       margin: marginRequired,
     });
 
-    // --- 6. 지갑 잔고에서 증거금 차감 및 거래 내역(Transaction) 기록 ---
-    // 먼저 사용자 지갑 객체를 가져옵니다.
+    // 6단계 로직을 '자산 변동 처리'로 통합하여 확장합니다.
+    // --- 6. 자산 변동 처리 (증거금 및 수수료) ---
     const wallet = await this.walletsService.findWalletByUserId(userId);
     if (!wallet) {
       throw new BadRequestException('사용자 지갑을 찾을 수 없습니다.');
@@ -87,14 +89,22 @@ export class OrdersService {
 
     // 6-1. 지갑 잔고 업데이트
     await this.walletsService.updateBalance(userId, -marginRequired);
-
-    // 6-2. 증거금 사용에 대한 거래 내역 생성
-    // (REALIZED_PNL은 포지션 종료 시점에 발생하므로, 지금은 증거금 사용에 대한 내역만 기록)
-    // 수수료 로직 추가 시, FEE 타입의 Transaction도 여기서 생성 가능
     await this.transactionsService.create({
       wallet: wallet,
-      type: TransactionType.REALIZED_PNL, // 지금은 '실현 손익'으로 분류 (추후 MARGIN 등으로 세분화 가능)
-      amount: -marginRequired, // 증거금은 자산에서 차감되므로 음수
+      type: TransactionType.REALIZED_PNL, // 증거금 사용은 손익 실현으로 간주
+      amount: -marginRequired,
+    });
+
+    // 6-2. [신규] 거래 수수료 계산 및 차감, 기록
+    const feeRate = this.configService.get<number>('TRADE_FEE_RATE');
+    const positionValue = marketPrice * quantity; // 포지션 총 가치
+    const tradeFee = positionValue * feeRate; // 수수료 계산
+
+    await this.walletsService.updateBalance(userId, -tradeFee);
+    await this.transactionsService.create({
+      wallet: wallet,
+      type: TransactionType.FEE, // 'FEE' 타입으로 기록
+      amount: -tradeFee, // 수수료는 차감되므로 음수
     });
 
     return { order: newOrder, position: newPosition };


### PR DESCRIPTION
## 📝 작업 내용 (Description)

> 주문 체결 시, 설정된 수수료율에 따라 거래 수수료를 계산하고 사용자 지갑에서 차감하며, 해당 내역을 `FEE` 타입의 `Transaction`으로 기록하는 기능을 구현

<br>

## ✅ 관련 이슈 (Related Issues)

- Closes #24 

<br>

## ✨ 변경점 (Changes)

- [X] `.env` 파일에 `TRADE_FEE_RATE` 환경 변수를 추가
- [X] `OrdersService`에서 수수료를 계산하고, 사용자 자산을 차감하며, `FEE` 타입의 `Transaction`을 생성하는 로직을 추가
- [X] `ConfigService`를 `OrdersService`에 주입하여 수수료율을 동적으로 관리하도록 수정

<br>

---

### Self-Checklist

- [X] `develop` 브랜치로 PR을 요청합니다.
- [X] PR 제목에 작업 유형을 명시했습니다. (예: `feat:`)