### PR TITLE
feat: #26 포지션 시장가 종료 및 손익 실현 로직 구현

### DIFF
--- a/backend/src/positions/positions.controller.ts
+++ b/backend/src/positions/positions.controller.ts
@@ -1,6 +1,13 @@
 // backend/src/positions/positions.controller.ts
 
-import { Controller, Get, UseGuards, Request } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  UseGuards,
+  Request,
+  Param,
+  Delete,
+} from '@nestjs/common';
 import { PositionsService } from './positions.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
@@ -16,5 +23,17 @@ export class PositionsController {
   findMyPositions(@Request() req: { user: { id: string } }) {
     const userId = req.user.id;
     return this.positionsService.findAllByUserId(userId);
+  }
+
+  /*
+- [기능 구현] 포지션 종료를 위한 API 엔드포인트를 추가합니다. (DELETE /:id)
+- JwtAuthGuard를 적용하여 본인의 포지션만 종료할 수 있도록 보호합니다.
+- URL 파라미터에서 positionId를, 요청 객체에서 userId를 가져와 서비스 로직으로 전달합니다.
+*/
+  @UseGuards(JwtAuthGuard)
+  @Delete(':id')
+  closePosition(@Param('id') positionId: string, @Request() req) {
+    const userId = req.user.id;
+    return this.positionsService.closePosition(positionId, userId);
   }
 }

--- a/backend/src/positions/positions.module.ts
+++ b/backend/src/positions/positions.module.ts
@@ -3,9 +3,17 @@ import { PositionsService } from './positions.service';
 import { PositionsController } from './positions.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Position } from './entities/position.entity';
+import { WalletsModule } from '../wallets/wallets.module';
+import { TransactionsModule } from '../transactions/transactions.module';
+import { BinanceModule } from 'src/binance/binance.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Position])],
+  imports: [
+    TypeOrmModule.forFeature([Position]),
+    WalletsModule,
+    TransactionsModule,
+    BinanceModule,
+  ],
   controllers: [PositionsController],
   providers: [PositionsService],
   exports: [PositionsService],

--- a/backend/src/positions/positions.service.ts
+++ b/backend/src/positions/positions.service.ts
@@ -1,8 +1,17 @@
-import { Injectable, Logger } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Position } from './entities/position.entity';
 import { PositionSide } from '../common/enums/order.enum';
+import { WalletsService } from '../wallets/wallets.service';
+import { TransactionsService } from '../transactions/transactions.service';
+import { BinanceApiService } from '../binance/binance.service';
+import { TransactionType } from '../transactions/entities/transaction.entity';
 
 // createOrUpdatePosition 메소드에 전달될 데이터 타입을 정의
 interface PositionParams {
@@ -22,6 +31,9 @@ export class PositionsService {
   constructor(
     @InjectRepository(Position)
     private readonly positionsRepository: Repository<Position>,
+    private readonly walletsService: WalletsService,
+    private readonly transactionsService: TransactionsService,
+    private readonly binanceApiService: BinanceApiService,
   ) {}
 
   /**
@@ -116,5 +128,68 @@ export class PositionsService {
 
       return this.positionsRepository.save(newPosition);
     }
+  }
+
+  /**
+   * [신규 구현] 특정 포지션을 시장가로 종료하고 손익을 정산합니다.
+   * @param positionId 종료할 포지션의 ID
+   * @param userId 요청한 사용자의 ID
+   * [기능 구현] 포지션 종료 및 손익 실현을 처리하는 `closePosition` 메소드를 구현합니다.
+   * 여러 서비스(Binance, Wallets, Transactions)와 협력하여 포지션 종료 트랜잭션을 처리합니다.
+   */
+  async closePosition(
+    positionId: string,
+    userId: string,
+  ): Promise<{ realizedPnl: number }> {
+    // 1. 포지션 조회 및 소유권 확인
+    const position = await this.positionsRepository.findOne({
+      where: { id: positionId },
+      relations: ['user'], // 소유자 정보를 함께 가져오기 위함
+    });
+
+    if (!position) {
+      throw new NotFoundException(`Position with ID ${positionId} not found.`);
+    }
+    if (position.user.id !== userId) {
+      throw new ForbiddenException(
+        'You are not allowed to close this position.',
+      );
+    }
+
+    // 2. 현재 시장가 조회
+    const closePrice = await this.binanceApiService.getMarketPrice(
+      position.symbol,
+    );
+
+    // 3. 실현 손익(Realized PNL) 계산
+    const quantity = Number(position.quantity);
+    const entryPrice = Number(position.entryPrice);
+    let realizedPnl: number;
+
+    if (position.side === PositionSide.LONG) {
+      realizedPnl = (closePrice - entryPrice) * quantity;
+    } else {
+      // SHORT
+      realizedPnl = (entryPrice - closePrice) * quantity;
+    }
+
+    // 4. 지갑에 자산 반환 (초기 증거금 + 실현 손익)
+    const margin = Number(position.margin);
+    const amountToReturn = margin + realizedPnl;
+    await this.walletsService.updateBalance(userId, amountToReturn);
+
+    // 5. 손익 내역을 Transaction으로 기록
+    const wallet = await this.walletsService.findWalletByUserId(userId);
+    await this.transactionsService.create({
+      wallet,
+      type: TransactionType.REALIZED_PNL,
+      amount: realizedPnl,
+    });
+
+    // 6. 포지션 삭제
+    await this.positionsRepository.remove(position);
+
+    this.logger.debug(`Position ${positionId} closed. PNL: ${realizedPnl}`);
+    return { realizedPnl };
   }
 }

--- a/frontend/src/components/PositionStatus/index.tsx
+++ b/frontend/src/components/PositionStatus/index.tsx
@@ -2,13 +2,14 @@
 
 import React from "react";
 import * as S from "./styles";
-import { type Position } from "../../services/orderService";
+import { type Position, closePosition } from "../../services/orderService";
 
 interface PositionStatusProps {
   positions: Position[];
   isLoading: boolean;
   error: string | null;
   markPrice: number;
+  onPositionClosed: () => void;
 }
 
 const PositionStatus: React.FC<PositionStatusProps> = ({
@@ -16,6 +17,7 @@ const PositionStatus: React.FC<PositionStatusProps> = ({
   isLoading,
   error,
   markPrice,
+  onPositionClosed,
 }) => {
   // PNL 계산 함수
   const calculatePnl = (position: Position) => {
@@ -38,6 +40,22 @@ const PositionStatus: React.FC<PositionStatusProps> = ({
     return { pnl: pnl.toFixed(2), pnlPercent: pnlPercent.toFixed(2) };
   };
 
+  const handleClosePosition = async (positionId: string) => {
+    if (!window.confirm("정말로 포지션을 종료하시겠습니까?")) {
+      return;
+    }
+    try {
+      await closePosition(positionId);
+      alert("포지션이 성공적으로 종료되었습니다.");
+      onPositionClosed(); // 부모 컴포넌트에 포지션 종료 사실을 알림
+    } catch (err: unknown) {
+      let message;
+      if (err instanceof Error) message = err.message;
+
+      alert(`포지션 종료에 실패했습니다: ${message || "알 수 없는 오류"}`);
+    }
+  };
+
   if (isLoading) {
     return <S.Container>로딩 중...</S.Container>;
   }
@@ -56,8 +74,11 @@ const PositionStatus: React.FC<PositionStatusProps> = ({
             <th>방향</th>
             <th>수량</th>
             <th>진입가</th>
+            <th>현재가</th>
+            <th>청산가</th>
+            <th>미실현손익(PNL)</th>
             <th>레버리지</th>
-            {/* <th>미실현손익(PNL)</th> */}
+            <th>작업</th>
           </tr>
         </thead>
         <tbody>
@@ -67,23 +88,30 @@ const PositionStatus: React.FC<PositionStatusProps> = ({
               return (
                 <tr key={pos.id}>
                   <td>{pos.symbol}</td>
-                  <S.PositionSideCell side={pos.side}>
+                  <S.PositionSideCell $side={pos.side}>
                     {pos.side}
                   </S.PositionSideCell>
-                  <td>{pos.quantity}</td>
+                  <td>{Number(pos.quantity).toFixed(8)}</td>
                   <td>{Number(pos.entryPrice).toFixed(2)}</td>
+                  {/* '현재가'와 '청산가' 컬럼을 명시적으로 추가 */}
                   <td>{markPrice.toFixed(2)}</td>
+                  <td>{Number(pos.liquidationPrice).toFixed(2)}</td>
+                  {/* PNL 셀 */}
                   <S.PnlCell $isPositive={Number(pnl) >= 0}>
                     {pnl} USDT ({pnlPercent}%)
                   </S.PnlCell>
                   <td>{pos.leverage}x</td>
-                  {/* <td>+12.34 USDT (2.45%)</td> */}
+                  <td>
+                    <S.CloseButton onClick={() => handleClosePosition(pos.id)}>
+                      종료
+                    </S.CloseButton>
+                  </td>
                 </tr>
               );
             })
           ) : (
             <tr>
-              <td colSpan={5}>보유 중인 포지션이 없습니다.</td>
+              <td colSpan={9}>보유 중인 포지션이 없습니다.</td>
             </tr>
           )}
         </tbody>

--- a/frontend/src/components/PositionStatus/styles.ts
+++ b/frontend/src/components/PositionStatus/styles.ts
@@ -51,8 +51,8 @@ export const Table = styled.table`
   }
 `;
 
-export const PositionSideCell = styled.td<{ side: 'LONG' | 'SHORT' }>`
-  color: ${({ side }) => (side === 'LONG' ? '#089981' : '#f23645')};
+export const PositionSideCell = styled.td<{ $side: 'LONG' | 'SHORT' }>`
+  color: ${({ $side }) => ($side === 'LONG' ? '#089981' : '#f23645')};
   font-weight: bold;
 `;
 
@@ -60,4 +60,19 @@ export const PositionSideCell = styled.td<{ side: 'LONG' | 'SHORT' }>`
 export const PnlCell = styled.td<{ $isPositive: boolean }>`
   color: ${({ $isPositive }) => ($isPositive ? '#089981' : '#f23645')};
   font-weight: 500;
+`;
+
+export const CloseButton = styled.button`
+  background-color: #373c4a;
+  color: #d1d4dc;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: #4a5060;
+  }
 `;

--- a/frontend/src/pages/TradingPage.tsx
+++ b/frontend/src/pages/TradingPage.tsx
@@ -136,7 +136,8 @@ export const TradingPage = () => {
           positions={positions}
           isLoading={isLoading}
           error={error}
-          markPrice={markPrice} 
+          markPrice={markPrice}
+          onPositionClosed={handleOrderSuccess}
         />
       </PositionStatusContainer>
     </TradingPageContainer>

--- a/frontend/src/services/orderService.ts
+++ b/frontend/src/services/orderService.ts
@@ -101,3 +101,20 @@ export const getMyWallet = async (): Promise<Wallet> => {
     throw new Error('알 수 없는 오류가 발생했습니다.');
   }
 };
+
+
+
+/**
+ * 특정 ID의 포지션을 종료합니다.
+ * @param positionId 종료할 포지션의 ID
+ * [기능 구현] 포지션을 종료하는 API를 호출하는 `closePosition` 함수를 추가합니다.
+ */
+export const closePosition = async (positionId: string): Promise<void> => {
+  try {
+    await apiClient.delete(`/positions/${positionId}`);
+  } catch (error) {
+    console.error(`Failed to close position ${positionId}:`, error);
+    // 실제 애플리케이션에서는 사용자에게 보여줄 에러 메시지를 throw하는 것이 좋습니다.
+    throw new Error('포지션 종료에 실패했습니다.');
+  }
+};


### PR DESCRIPTION
## 📝 작업 내용 (Description)

> 사용자가 보유 중인 포지션을 현재 시장가로 즉시 종료하고, 발생한 손익을 계산하여 지갑 잔고에 반영하는 기능을 구현

<br>

## ✅ 관련 이슈 (Related Issues)

- Closes #26 

<br>

## ✨ 변경점 (Changes)

- [X] **Backend:** 포지션 종료를 위한 API 엔드포인트(`DELETE /api/positions/:id`)를 추가
- [X] **Backend:** `PositionsService`에 실현 손익(PNL) 계산, 자산 정산, 거래 기록, 포지션 삭제를 포함한 `closePosition` 메소드를 구현
- [X] **Frontend:** `PositionStatus` 컴포넌트에 '종료' 버튼을 추가하고, API 연동 및 성공 시 UI 새로고침 로직을 구현
- [X] **Frontend:** `PositionStatus` 테이블 구조를 개선하여 현재가, 청산가 컬럼을 추가하고 렌더링 오류를 수정

<br>

---

### Self-Checklist

- [X] `develop` 브랜치로 PR을 요청합니다.
- [X] PR 제목에 작업 유형을 명시했습니다. (예: `feat:`)