### PR TITLE
feat: #28 포지션 자동 청산 실행 로직 구현

### DIFF
--- a/backend/src/binance/binance.module.ts
+++ b/backend/src/binance/binance.module.ts
@@ -1,9 +1,10 @@
 // backend/src/binance/binance.module.ts
 
-import { Module } from '@nestjs/common';
-import { HttpModule } from '@nestjs/axios'; // HttpModule 임포트
+import { Module, forwardRef } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
 import { BinanceApiService } from './binance.service';
 import { EventsModule } from '../events/events.module';
+import { PositionsModule } from '../positions/positions.module';
 
 @Module({
   imports: [
@@ -13,8 +14,9 @@ import { EventsModule } from '../events/events.module';
       maxRedirects: 5, // 최대 리다이렉트 횟수
     }),
     EventsModule,
+    forwardRef(() => PositionsModule),
   ],
-  providers: [BinanceApiService], // 서비스는 다음 단계에서 추가
+  providers: [BinanceApiService],
   exports: [BinanceApiService],
 })
 export class BinanceModule {}

--- a/backend/src/binance/binance.service.ts
+++ b/backend/src/binance/binance.service.ts
@@ -2,6 +2,8 @@
 
 import {
   Injectable,
+  Inject,
+  forwardRef,
   OnModuleInit,
   InternalServerErrorException,
   Logger,
@@ -11,6 +13,7 @@ import { ConfigService } from '@nestjs/config';
 import { firstValueFrom, map } from 'rxjs';
 import * as WebSocket from 'ws';
 import { EventsGateway } from 'src/events/events.gateway';
+import { PositionsService } from 'src/positions/positions.service';
 
 @Injectable()
 export class BinanceApiService implements OnModuleInit {
@@ -24,6 +27,8 @@ export class BinanceApiService implements OnModuleInit {
     private readonly httpService: HttpService,
     private readonly configService: ConfigService,
     private readonly eventsGateway: EventsGateway,
+    @Inject(forwardRef(() => PositionsService))
+    private readonly positionsService: PositionsService,
   ) {
     // .env에서 API 키를 안전하게 가져옴
     this.apiKey = this.configService.getOrThrow<string>('BINANCE_API_KEY');
@@ -54,6 +59,31 @@ export class BinanceApiService implements OnModuleInit {
       }
     } catch (error) {
       console.error('❌ Error pinging Binance API:', error.message);
+    }
+  }
+
+  /**
+   * [신규 추가] 자동 청산 로직을 처리하는 비동기 메소드
+   * @param markPrice 현재 시장가
+   */
+  private async handleLiquidationCheck(markPrice: number): Promise<void> {
+    try {
+      const liquidatablePositions =
+        await this.positionsService.findLiquidatablePositions(markPrice);
+
+      if (liquidatablePositions.length > 0) {
+        this.logger.warn(
+          `Found ${liquidatablePositions.length} positions to liquidate at price ${markPrice}`,
+        );
+
+        const liquidationPromises = liquidatablePositions.map((position) =>
+          this.positionsService.closePosition(position.id, position.user.id),
+        );
+
+        await Promise.all(liquidationPromises);
+      }
+    } catch (error) {
+      this.logger.error('Error during liquidation check:', error);
     }
   }
 
@@ -98,6 +128,10 @@ export class BinanceApiService implements OnModuleInit {
           } else if (message.stream.endsWith('@aggTrade')) {
             // 체결 데이터 처리 (클라이언트에 'trade' 이벤트로 전송)
             this.eventsGateway.server.emit('trade', message.data);
+
+            const markPrice = parseFloat(message.data.p);
+
+            void this.handleLiquidationCheck(markPrice);
           }
         }
       } catch (error) {

--- a/backend/src/positions/positions.module.ts
+++ b/backend/src/positions/positions.module.ts
@@ -1,18 +1,18 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { PositionsService } from './positions.service';
 import { PositionsController } from './positions.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Position } from './entities/position.entity';
 import { WalletsModule } from '../wallets/wallets.module';
 import { TransactionsModule } from '../transactions/transactions.module';
-import { BinanceModule } from 'src/binance/binance.module';
+import { BinanceModule } from '../binance/binance.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Position]),
     WalletsModule,
     TransactionsModule,
-    BinanceModule,
+    forwardRef(() => BinanceModule),
   ],
   controllers: [PositionsController],
   providers: [PositionsService],

--- a/backend/src/positions/positions.service.ts
+++ b/backend/src/positions/positions.service.ts
@@ -1,5 +1,7 @@
 import {
   Injectable,
+  Inject,
+  forwardRef,
   Logger,
   NotFoundException,
   ForbiddenException,
@@ -33,6 +35,7 @@ export class PositionsService {
     private readonly positionsRepository: Repository<Position>,
     private readonly walletsService: WalletsService,
     private readonly transactionsService: TransactionsService,
+    @Inject(forwardRef(() => BinanceApiService))
     private readonly binanceApiService: BinanceApiService,
   ) {}
 
@@ -131,11 +134,11 @@ export class PositionsService {
   }
 
   /**
-   * [신규 구현] 특정 포지션을 시장가로 종료하고 손익을 정산합니다.
+   * 특정 포지션을 시장가로 종료하고 손익을 정산
    * @param positionId 종료할 포지션의 ID
    * @param userId 요청한 사용자의 ID
-   * [기능 구현] 포지션 종료 및 손익 실현을 처리하는 `closePosition` 메소드를 구현합니다.
-   * 여러 서비스(Binance, Wallets, Transactions)와 협력하여 포지션 종료 트랜잭션을 처리합니다.
+   * [기능 구현] 포지션 종료 및 손익 실현을 처리하는 `closePosition` 메소드를 구현
+   * 여러 서비스(Binance, Wallets, Transactions)와 협력하여 포지션 종료 트랜잭션을 처리
    */
   async closePosition(
     positionId: string,
@@ -191,5 +194,31 @@ export class PositionsService {
 
     this.logger.debug(`Position ${positionId} closed. PNL: ${realizedPnl}`);
     return { realizedPnl };
+  }
+
+  /**
+   * 청산 대상 포지션을 찾음
+   * @param markPrice 현재 시장가
+   * @returns 청산되어야 할 포지션들의 배열
+   * 현재 시장가를 기준으로 청산되어야 할 모든 포지션을 조회하는 `findLiquidatablePositions` 메소드를 추가
+   * 이 메소드는 롱/숏 포지션의 청산 조건을 각각 검사하여 대상 목록을 반환
+   */
+  async findLiquidatablePositions(markPrice: number): Promise<Position[]> {
+    const openPositions = await this.positionsRepository.find({
+      relations: ['user'],
+    }); // DB에서 모든 오픈 포지션을 가져옵니다.
+
+    const liquidatablePositions = openPositions.filter((position) => {
+      const liquidationPrice = Number(position.liquidationPrice);
+      if (position.side === PositionSide.LONG) {
+        // 롱 포지션은 시장가가 청산가 이하로 떨어지면 청산 대상입니다.
+        return markPrice <= liquidationPrice;
+      } else {
+        // 숏 포지션은 시장가가 청산가 이상으로 올라가면 청산 대상입니다.
+        return markPrice >= liquidationPrice;
+      }
+    });
+
+    return liquidatablePositions;
   }
 }

--- a/frontend/src/components/PositionStatus/index.tsx
+++ b/frontend/src/components/PositionStatus/index.tsx
@@ -52,7 +52,7 @@ const PositionStatus: React.FC<PositionStatusProps> = ({
       let message;
       if (err instanceof Error) message = err.message;
 
-      alert(`포지션 종료에 실패했습니다: ${message || "알 수 없는 오류"}`);
+      alert(`${message || "알 수 없는 오류"}`);
     }
   };
 


### PR DESCRIPTION
## 📝 작업 내용 (Description)

> 실시간 시장 가격이 포지션의 청산 가격에 도달하면, 시스템이 해당 포지션을 자동으로 종료시키는 기능을 구현

<br>

## ✅ 관련 이슈 (Related Issues)

- Closes #28 

<br>

## ✨ 변경점 (Changes)

- [X] **Backend:** `BinanceApiService`에서 실시간 체결가 수신 시, `PositionsService`를 호출하여 청산 대상 포지션을 찾는 로직을 추가
- [X] **Backend:** 청산 대상이 발견되면 `PositionsService.closePosition`을 호출하여 자동으로 포지션을 종료하도록 구현
- [X] **Backend (Fix):** `BinanceModule`과 `PositionsModule` 간의 순환 의존성(Circular Dependency) 문제를 `forwardRef()`와 `@Inject` 데코레이터를 사용하여 해결

<br>

---

### Self-Checklist

- [X] `develop` 브랜치로 PR을 요청합니다.
- [X] PR 제목에 작업 유형을 명시했습니다. (예: `feat:`)